### PR TITLE
H361: Direction-Magnitude decomposed WSS loss — WSS_z geometric attack

### DIFF
--- a/train.py
+++ b/train.py
@@ -54,6 +54,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     loader_kwargs,
     make_loaders,
+    masked_mean,
     masked_mse,
     metric_namespace,
     weighted_channel_mse,
@@ -106,6 +107,14 @@ class Config:
     drop_path_max: float = 0.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    # H361: direction-magnitude decomposed WSS loss
+    # added on top of the per-channel surface MSE (does not replace it).
+    # alpha weights (1 - cosine_similarity) on the WSS vector (tau_x, tau_y, tau_z);
+    # beta weights relative-magnitude MSE on the vector norm.
+    # Both terms operate on normalized-space WSS (same space as the base MSE).
+    # Both 0.0 = disabled (loss is exactly the existing MSE).
+    wss_dir_loss_alpha: float = 0.0
+    wss_dir_loss_beta: float = 0.0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -432,6 +441,36 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+def wss_direction_magnitude_loss(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    *,
+    alpha: float = 1.0,
+    beta: float = 1.0,
+    eps: float = 1e-6,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Decomposed WSS loss: alpha * (1 - cos_sim) + beta * relative_norm_mse.
+
+    pred / target: [B, N, 3] — WSS channels (tau_x, tau_y, tau_z) only,
+    in the same space as the base MSE (normalized).
+    mask: [B, N]. Returns (combined_loss, dir_loss, rel_mag_loss).
+    """
+    # eps inside the sqrt is the numerically stable L2-norm idiom: it keeps the
+    # backward gradient ``x / (||x||^2 + eps^2).sqrt()`` bounded for near-zero
+    # vectors (clamp on the output protects the forward only).
+    eps_sq = eps * eps
+    pred_norm = (pred.pow(2).sum(dim=-1) + eps_sq).sqrt()  # [B, N]
+    tgt_norm = (target.pow(2).sum(dim=-1) + eps_sq).sqrt()  # [B, N]
+    dot = (pred * target).sum(dim=-1)                       # [B, N]
+    cos_sim = dot / (pred_norm * tgt_norm)                  # [B, N]
+    dir_loss = masked_mean(1.0 - cos_sim, mask)
+    mag_sq_err = (pred_norm - tgt_norm).square()
+    rel_mag_loss = masked_mean(mag_sq_err / (tgt_norm.square() + eps_sq), mask)
+    combined = alpha * dir_loss + beta * rel_mag_loss
+    return combined, dir_loss, rel_mag_loss
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -442,6 +481,8 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    wss_dir_loss_alpha: float = 0.0,
+    wss_dir_loss_beta: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -462,18 +503,37 @@ def train_loss(
             )
         else:
             surface_loss = masked_mse(out["surface_preds"], surface_target, batch.surface_mask)
+        wss_dir_extra_loss: torch.Tensor | None = None
+        wss_dir_component: torch.Tensor | None = None
+        wss_mag_component: torch.Tensor | None = None
+        if wss_dir_loss_alpha > 0.0 or wss_dir_loss_beta > 0.0:
+            wss_pred = out["surface_preds"][..., 1:4]
+            wss_true = surface_target[..., 1:4]
+            wss_dir_extra_loss, wss_dir_component, wss_mag_component = wss_direction_magnitude_loss(
+                wss_pred,
+                wss_true,
+                batch.surface_mask,
+                alpha=wss_dir_loss_alpha,
+                beta=wss_dir_loss_beta,
+            )
+            surface_loss = surface_loss + wss_dir_extra_loss
         volume_loss = masked_mse(out["volume_preds"], volume_target, batch.volume_mask)
         weighted_surface_loss = surface_loss_weight * surface_loss
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics_out = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    if wss_dir_extra_loss is not None:
+        metrics_out["wss_dir_extra_loss"] = float(wss_dir_extra_loss.detach().cpu().item())
+        metrics_out["wss_dir_component"] = float(wss_dir_component.detach().cpu().item())
+        metrics_out["wss_mag_component"] = float(wss_mag_component.detach().cpu().item())
+    return loss, metrics_out
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -1064,6 +1124,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/wss_dir_loss_alpha"] = config.wss_dir_loss_alpha
+            wandb.summary["loss/wss_dir_loss_beta"] = config.wss_dir_loss_beta
             backbone = getattr(base_model, "backbone", None)
             if backbone is not None and hasattr(backbone, "blocks"):
                 drop_path_schedule = [
@@ -1230,6 +1292,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        wss_dir_loss_alpha=config.wss_dir_loss_alpha,
+                        wss_dir_loss_beta=config.wss_dir_loss_beta,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1268,8 +1332,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                             "train/tau_y_loss_weight": config.tau_y_loss_weight,
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
+                            "train/wss_dir_loss_alpha": config.wss_dir_loss_alpha,
+                            "train/wss_dir_loss_beta": config.wss_dir_loss_beta,
                         }
                     )
+                    if "wss_dir_extra_loss" in batch_loss_metrics:
+                        train_log["train/wss_dir_extra_loss"] = batch_loss_metrics["wss_dir_extra_loss"]
+                        train_log["train/wss_dir_component"] = batch_loss_metrics["wss_dir_component"]
+                        train_log["train/wss_mag_component"] = batch_loss_metrics["wss_mag_component"]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**Direction-Magnitude Decomposed WSS Loss** — decompose the WSS training gradient into (1) a cosine-similarity term that targets *direction* error and (2) a relative-norm term that targets *magnitude* error. The current per-channel MSE (even with `tau_z_loss_weight=1.67`) conflates these into a single scalar gradient per point, which underfits high-curvature vortex-shedding regions (wheel arches, door mirrors, A-pillar separation) where direction error and magnitude error have different difficulty/noise characteristics.

This is **structurally different** from the 3 closed scalar-reweight axes (H339 uniform, H341 wz-only, H346 per-vertex focal) — those tested scalar weights on existing MSE. H361 changes the loss **geometry** itself: cosine gradient pushes pred-direction → true-direction; relative-norm gradient pushes ‖pred‖ → ‖true‖. The two gradient fields are qualitatively different and can decompose a failure mode that a single scalar weight cannot.

**Mechanistic story**: WSS_z floor at 8.6122% has been falsified at every scalar reweight axis and every TTA axis. The remaining hypothesis is that the gradient signal itself is the wrong geometric object. Cosine + relative-magnitude is the natural decomposition for vector targets on a surface — used in vector field regression literature but never tried in this codebase.

**External evidence**: NVIDIA's GeoTransolver paper (arxiv:2512.20399) reports test_WSS=4.9% on DrivAerML — a 92bp delta over our 5.85% target. Their improvement comes from architectural changes (geometric cross-attention), which independently confirms WSS prediction is a representation-quality problem, not optimization. H361 is the loss-geometry version of the same hypothesis — fast to test, and serves as a clean discriminator: if H361 is null, the bottleneck is definitively architectural and we should escalate to GeoTransolver-style mods.

## Instructions

### Step 1 — implement loss function (train.py only)

Add after the existing `masked_mse` definition:

```python
def wss_direction_magnitude_loss(
    pred: torch.Tensor,    # [B, N, 3] — WSS channels τ_x, τ_y, τ_z only
    target: torch.Tensor,  # [B, N, 3]
    mask: torch.Tensor,    # [B, N]
    alpha: float = 1.0,
    beta: float = 1.0,
    eps: float = 1e-6,
) -> torch.Tensor:
    """Decomposed WSS loss: alpha · (1 - cos_sim) + beta · relative_norm_mse."""
    dot = (pred * target).sum(-1, keepdim=True)          # [B, N, 1]
    pred_norm = pred.norm(dim=-1, keepdim=True).clamp(min=eps)
    tgt_norm  = target.norm(dim=-1, keepdim=True).clamp(min=eps)
    cos_sim = dot / (pred_norm * tgt_norm)               # [B, N, 1]
    dir_loss = masked_mean((1.0 - cos_sim).squeeze(-1), mask)
    mag_sq_err = (pred_norm.squeeze(-1) - tgt_norm.squeeze(-1)).square()
    rel_mag_loss = masked_mean(mag_sq_err / (tgt_norm.squeeze(-1).square() + eps), mask)
    return alpha * dir_loss + beta * rel_mag_loss
```

### Step 2 — Config flags (train.py Config dataclass)

```python
wss_dir_loss_alpha: float = 0.0   # 0.0 = disabled (control)
wss_dir_loss_beta: float = 0.0    # 0.0 = disabled (control)
```

### Step 3 — Wire into train_loss

After `surface_loss = masked_mse(...)` (keep this intact, including `tau_z_loss_weight=1.67`):

```python
if config.wss_dir_loss_alpha > 0.0 or config.wss_dir_loss_beta > 0.0:
    wss_pred = out["surface_preds"][..., 1:4]   # τ_x, τ_y, τ_z (verify channel layout in model.py before running)
    wss_true = surface_target[..., 1:4]
    wss_extra = wss_direction_magnitude_loss(
        wss_pred, wss_true, batch.surface_mask,
        alpha=config.wss_dir_loss_alpha,
        beta=config.wss_dir_loss_beta,
    )
    surface_loss = surface_loss + wss_extra
```

**Verify channel layout first.** In `model.py` confirm `surface_preds[..., 0]` = cp and `surface_preds[..., 1:4]` = τ_x, τ_y, τ_z. If different, slice accordingly. **Do NOT modify model.py** — read-only sanity check only.

### Step 4 — Smoke (5 min, sanity wiring)

```bash
torchrun --nproc_per_node=8 train.py \
  --epochs 1 --agent edward \
  --wandb_name "edward/h361-smoke" \
  --wandb_group h361-wss-dirloss \
  --wss_dir_loss_alpha 0.5 --wss_dir_loss_beta 0.5 \
  --tau_z_loss_weight 1.67 \
  --train_surface_points 8000 --eval_surface_points 8000 \
  --train_volume_points 8000 --eval_volume_points 8000 \
  --kill-thresholds "20:train/loss<1000"
```

Expect: smoke completes ~5min, `train/loss` finite and decreasing.

### Step 5 — Phase 1 Arm A (3-epoch fine-tune from H336 EP13, ~6.5h)

Find the H336 EP13 run ID (you used this in H312 and H338 — same checkpoint resume). Then:

```bash
torchrun --nproc_per_node=8 train.py \
  --epochs 16 --epochs_already_done 13 \
  --agent edward \
  --wandb_name "edward/h361-armA-a0.5b0.5" \
  --wandb_group h361-wss-dirloss \
  --resume_from_wandb <H336_EP13_RUN_ID> --resume_alias epoch-13 \
  --lr 1e-4 --lr_cosine_t_max 3 --lr_min 1e-6 \
  --tau_z_loss_weight 1.67 \
  --wss_dir_loss_alpha 0.5 --wss_dir_loss_beta 0.5 \
  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25"
```

### Step 6 — TTA + cal eval (identical to H342)

K=5, Student-t ν=4, σ=5e-4, mirror, 8 resolutions 32k→131k, per-channel OLS cal. Use the same eval script you used for H338 / H312. Report val_abupt_calibrated, test_abupt_calibrated, full per-axis breakdown especially test_WSS_z.

### Step 7 — Phase 1 Arm B (conditional, only if Arm A val_raw < 5.93)

Direction-dominant: `--wss_dir_loss_alpha 1.0 --wss_dir_loss_beta 0.25`. Same Phase 1 + TTA cascade. ~6.5h.

## Pre-committed close rules

Close immediately if ANY:
- Smoke: `train/loss` NaN or >10 after 20 steps
- Phase 1 EP14: `val_primary/abupt_axis_mean_rel_l2_pct > 6.05` (>10bp above SOTA raw — cal cannot rescue per `cal-cannot-rescue-train-raw-regression`)
- Phase 1 final EP16: `val_raw > 5.98` (no improvement over H342 baseline raw)
- Phase 1 final EP16: `val_raw 5.93-5.98` → run TTA on val only; if val_cal misses gate by >5bp, close (don't burn test eval)

**Proceed to full TTA+test eval only if Phase 1 val_raw < 5.93.**

## Baseline

Current SOTA: **H342 3-cp output-avg ep13+ep14+ep15 × K=4 TTA (PR #1526 MERGED)**

| Metric | H342 SOTA | Merge gate |
|---|---:|---:|
| **val_abupt_calibrated** | **5.8962%** | < **5.8962%** |
| **test_abupt_calibrated** | **5.7357%** | < **5.7357%** |
| test_WSS_z_cal | 8.6122% | (target obstacle, Transolver-3 floor 5.85%) |
| test_VP_cal | 3.3751% | (safely under 3.421 floor) |
| test_SP_cal | 3.6124% | (over 3.577 floor by +3.5bp — secondary) |

**Merge gate**: val_cal < **5.8962%** AND test_cal < **5.7357%** (AND-logic)

**W&B run IDs (reference)**:
- H342 SOTA evals: 3icmxaqe (ep15), qgw0ix77 (ep14), ijadzof0 (ep13)
- H336 EP13 source checkpoint: look up `nezuko/h336-*` runs in W&B (you've used these as source in prior experiments)

## Constraints (REINFORCED)

- **z-axis τ_z LOCKED at trained value 1.67** — do NOT modify `tau_z_loss_weight`
- **Read-only files**: `data/loader.py`, `data/preload.py`, `data/split_manifest.json`
- **DDP 8-GPU mandatory** — every training run uses `torchrun --nproc_per_node=8`
- **SENPAI_TIMEOUT_MINUTES=540** hard cap
- **No param overhead** — H361 is loss-only, zero new params, must remain so
- **No ensembles** (lazy route, Morgan)
- One terminal `SENPAI-RESULT` marker required for merge consideration

## Reproduce command (for advisor verification)

```bash
cd target && torchrun --nproc_per_node=8 train.py \
  --epochs 16 --epochs_already_done 13 --agent edward \
  --wandb_name "edward/h361-armA-a0.5b0.5" \
  --wandb_group h361-wss-dirloss \
  --resume_from_wandb <H336_EP13_RUN_ID> --resume_alias epoch-13 \
  --lr 1e-4 --lr_cosine_t_max 3 --lr_min 1e-6 \
  --tau_z_loss_weight 1.67 \
  --wss_dir_loss_alpha 0.5 --wss_dir_loss_beta 0.5
```
