### PR TITLE
H363: Physics-regime mixture-of-experts surface WSS decoder (Morgan P4)

### DIFF
--- a/model.py
+++ b/model.py
@@ -435,35 +435,39 @@ class MoESurfaceDecoder(nn.Module):
         self.num_experts = num_experts
         expert_hidden = expert_hidden or (hidden_dim // 2)
         self.expert_hidden = expert_hidden
-        self.experts = nn.ModuleList(
-            [
-                nn.Sequential(
-                    nn.Linear(hidden_dim, expert_hidden),
-                    nn.GELU(),
-                    nn.Linear(expert_hidden, out_dim),
-                )
-                for _ in range(num_experts)
-            ]
-        )
-        # Hidden Linear: trunc_normal init for stable forward dynamics.
-        # Output Linear: zero-init weight and bias so each expert contributes
-        # exactly zero at init, preserving the base-head step-0 prediction.
-        for expert in self.experts:
-            nn.init.trunc_normal_(expert[0].weight, std=0.02)
-            nn.init.zeros_(expert[0].bias)
-            nn.init.zeros_(expert[-1].weight)
-            nn.init.zeros_(expert[-1].bias)
+        # Batched expert parameters: shape [num_experts, in_dim, out_dim].
+        # We use einsum-style batched linears (rather than a ModuleList of
+        # nn.Sequential) so the forward graph has no per-expert Python loop;
+        # this keeps torch.compile / Inductor happy on dynamic shapes (a
+        # stacked-list approach trips a CantSplit tiling failure on the
+        # fused MoE+pos-embed kernel).
+        self.W1 = nn.Parameter(torch.empty(num_experts, hidden_dim, expert_hidden))
+        self.b1 = nn.Parameter(torch.zeros(num_experts, expert_hidden))
+        self.W2 = nn.Parameter(torch.zeros(num_experts, expert_hidden, out_dim))
+        self.b2 = nn.Parameter(torch.zeros(num_experts, out_dim))
+        nn.init.trunc_normal_(self.W1, std=0.02)
+        # W2 / b2 / b1 already zero — zero-init residual preserves step-0
+        # surface_preds == base_head(h) (verified in tools/h363_step0_check.py).
         self.router = nn.Linear(hidden_dim, num_experts)
         nn.init.normal_(self.router.weight, std=0.01)
         nn.init.zeros_(self.router.bias)
 
+    # Inductor's tile-splitting (CantSplit) fails on the batched expert einsum
+    # when surface_tokens is a dynamic dim, deadlocking DDP. Skip torch.compile
+    # for this module only — the rest of the graph still compiles normally.
+    @torch._dynamo.disable
     def forward(self, h: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         # h: [..., hidden_dim]
         logits = self.router(h)
         probs = F.softmax(logits, dim=-1)
-        expert_outputs = torch.stack([expert(h) for expert in self.experts], dim=-2)
-        # expert_outputs: [..., num_experts, out_dim]
-        out = (probs.unsqueeze(-1) * expert_outputs).sum(dim=-2)
+        # Batched expert hidden + output via einsum. Equivalent to running
+        # each expert MLP independently then stacking, but with a single
+        # fused kernel.
+        h_e = torch.einsum("...h,ehk->...ek", h, self.W1) + self.b1
+        h_act = F.gelu(h_e)
+        out_e = torch.einsum("...ek,eko->...eo", h_act, self.W2) + self.b2
+        # Soft mixture: probs [..., num_experts] x out_e [..., num_experts, out_dim].
+        out = (probs.unsqueeze(-1) * out_e).sum(dim=-2)
         return out, probs
 
 

--- a/model.py
+++ b/model.py
@@ -394,6 +394,79 @@ class Transformer(nn.Module):
         return x
 
 
+class MoESurfaceDecoder(nn.Module):
+    """H363: Physics-regime mixture-of-experts surface decoder (residual).
+
+    Adds a soft-mixture residual on top of the existing surface head. Each
+    expert is a 2-layer MLP ``Linear -> GELU -> Linear`` with zero-init on
+    the output Linear weight and bias so the residual is exactly zero at
+    init, preserving the step-0 prediction of the base surface head (and
+    therefore the EP13 resumed-checkpoint validation metric).
+
+    A small linear router maps each surface token's hidden state to a
+    softmax over experts; the per-token output is the soft mixture
+    ``sum_i p_i(h) * expert_i(h)``. Switch-Transformer-style load-balance
+    auxiliary loss is computed in ``train.py`` from the returned ``probs``.
+
+    Parameters
+    ----------
+    hidden_dim:
+        Input hidden width (matches the surface decoder input width).
+    out_dim:
+        Output dimension (surface_output_dim, e.g. 4 = [cp, tau_x, tau_y, tau_z]).
+    num_experts:
+        Number of mixture components (e.g. 2 in Arm A, 4 in Arm B).
+    expert_hidden:
+        Width of each expert's hidden layer; defaults to ``hidden_dim // 2``.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        out_dim: int,
+        num_experts: int = 2,
+        expert_hidden: int | None = None,
+    ):
+        super().__init__()
+        if num_experts < 2:
+            raise ValueError("MoESurfaceDecoder requires num_experts >= 2")
+        self.hidden_dim = hidden_dim
+        self.out_dim = out_dim
+        self.num_experts = num_experts
+        expert_hidden = expert_hidden or (hidden_dim // 2)
+        self.expert_hidden = expert_hidden
+        self.experts = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Linear(hidden_dim, expert_hidden),
+                    nn.GELU(),
+                    nn.Linear(expert_hidden, out_dim),
+                )
+                for _ in range(num_experts)
+            ]
+        )
+        # Hidden Linear: trunc_normal init for stable forward dynamics.
+        # Output Linear: zero-init weight and bias so each expert contributes
+        # exactly zero at init, preserving the base-head step-0 prediction.
+        for expert in self.experts:
+            nn.init.trunc_normal_(expert[0].weight, std=0.02)
+            nn.init.zeros_(expert[0].bias)
+            nn.init.zeros_(expert[-1].weight)
+            nn.init.zeros_(expert[-1].bias)
+        self.router = nn.Linear(hidden_dim, num_experts)
+        nn.init.normal_(self.router.weight, std=0.01)
+        nn.init.zeros_(self.router.bias)
+
+    def forward(self, h: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        # h: [..., hidden_dim]
+        logits = self.router(h)
+        probs = F.softmax(logits, dim=-1)
+        expert_outputs = torch.stack([expert(h) for expert in self.experts], dim=-2)
+        # expert_outputs: [..., num_experts, out_dim]
+        out = (probs.unsqueeze(-1) * expert_outputs).sum(dim=-2)
+        return out, probs
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -419,6 +492,8 @@ class SurfaceTransolver(nn.Module):
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
         drop_path_max: float = 0.0,
+        moe_surface_decoder: bool = False,
+        moe_num_experts: int = 2,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -434,6 +509,8 @@ class SurfaceTransolver(nn.Module):
         self.use_surf_to_vol_xattn = use_surf_to_vol_xattn
         self.use_aux_decoder_heads = use_aux_decoder_heads
         self.drop_path_max = drop_path_max
+        self.moe_surface_decoder = moe_surface_decoder
+        self.moe_num_experts = moe_num_experts
         surface_extra_dim = max(0, self.surface_input_dim - space_dim)
         volume_extra_dim = max(0, self.volume_input_dim - space_dim)
 
@@ -537,6 +614,21 @@ class SurfaceTransolver(nn.Module):
         else:
             self.surface_out = LinearProjection(n_hidden, self.surface_output_dim)
             self.volume_out = LinearProjection(n_hidden, self.volume_output_dim)
+
+        # H363: Physics-regime mixture-of-experts surface decoder.
+        # Lives as a *residual* on top of the existing surface head so the
+        # zero-init expert outputs preserve the step-0 prediction exactly
+        # (otherwise a pure replacement would zero out the EP13-trained base
+        # head and fail the smoke-gate). When enabled, the surface prediction
+        # is computed as ``base_head(h) + moe_decoder(h)``.
+        if moe_surface_decoder:
+            self.moe_decoder = MoESurfaceDecoder(
+                hidden_dim=n_hidden,
+                out_dim=self.surface_output_dim,
+                num_experts=moe_num_experts,
+            )
+        else:
+            self.moe_decoder = None
 
         # Surface->volume cross-attention (PR #823): single MHA sublayer where
         # volume hidden states (Q) attend to surface hidden states (K/V).
@@ -660,8 +752,13 @@ class SurfaceTransolver(nn.Module):
             volume_hidden = self.surf_to_vol_xattn_norm(volume_hidden + xattn_out)
             volume_hidden = _apply_token_mask(volume_hidden, volume_mask)
 
+        moe_probs: torch.Tensor | None = None
         if surface_x is not None:
-            surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            surface_preds = self.surface_out(surface_hidden)
+            if self.moe_decoder is not None:
+                moe_residual, moe_probs = self.moe_decoder(surface_hidden)
+                surface_preds = surface_preds + moe_residual
+            surface_preds = surface_preds * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)
@@ -672,10 +769,13 @@ class SurfaceTransolver(nn.Module):
             batch_size = surface_x.shape[0]
             volume_preds = surface_hidden.new_zeros(batch_size, 0, self.volume_output_dim)
 
-        return {
+        result: dict[str, torch.Tensor] = {
             "surface_preds": surface_preds,
             "volume_preds": volume_preds,
             "hidden": hidden,
             "surface_hidden": surface_hidden,
             "volume_hidden": volume_hidden,
         }
+        if moe_probs is not None:
+            result["moe_probs"] = moe_probs
+        return result

--- a/tools/h363_step0_check.py
+++ b/tools/h363_step0_check.py
@@ -1,0 +1,106 @@
+"""H363 step-0 invariant smoke check.
+
+Builds two SurfaceTransolver instances with identical seeds — one with the
+MoE residual decoder enabled (zero-init experts), one without — and verifies
+that their surface predictions are bit-identical on a random forward pass.
+This validates the smoke-gate claim that zero-init expert output Linears
+preserve the EP13 base-head prediction at step 0.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import torch
+
+sys.path.insert(0, ".")
+
+from model import SurfaceTransolver  # noqa: E402
+
+
+def build_model(moe: bool, num_experts: int = 2) -> SurfaceTransolver:
+    torch.manual_seed(0)
+    return SurfaceTransolver(
+        space_dim=3,
+        surface_input_dim=11,
+        volume_input_dim=8,
+        surface_output_dim=4,
+        volume_output_dim=1,
+        n_layers=2,
+        n_hidden=64,
+        n_head=2,
+        slice_num=8,
+        mlp_ratio=2,
+        dropout=0.0,
+        rff_num_features=4,
+        rff_init_sigmas=(0.5, 1.0, 2.0, 4.0),
+        pos_encoding_mode="string_separable",
+        use_qk_norm=True,
+        use_surf_to_vol_xattn=False,
+        drop_path_max=0.0,
+        moe_surface_decoder=moe,
+        moe_num_experts=num_experts,
+    )
+
+
+def main() -> int:
+    base = build_model(moe=False).eval()
+    moe = build_model(moe=True, num_experts=2).eval()
+
+    # Copy shared weights from base into moe so only the MoE-extra parameters
+    # differ. Both models were built with the same seed but slight RNG drift
+    # from the extra Module construction can offset later inits; we restore
+    # bit-identity for the shared backbone.
+    moe_state = moe.state_dict()
+    base_state = base.state_dict()
+    for k, v in base_state.items():
+        if k in moe_state:
+            moe_state[k].copy_(v)
+    moe.load_state_dict(moe_state, strict=False)
+
+    # Sanity: expert output weights/biases must be zero (batched einsum form).
+    assert torch.all(moe.moe_decoder.W2 == 0), "MoE W2 has nonzero entries"
+    assert torch.all(moe.moe_decoder.b2 == 0), "MoE b2 has nonzero entries"
+    print("expert output Linears: ZERO (OK)")
+
+    # Build a tiny random batch.
+    torch.manual_seed(123)
+    B = 2
+    N_s = 32
+    N_v = 16
+    surface_x = torch.randn(B, N_s, 11)
+    surface_mask = torch.ones(B, N_s)
+    volume_x = torch.randn(B, N_v, 8)
+    volume_mask = torch.ones(B, N_v)
+
+    with torch.no_grad():
+        out_base = base(
+            surface_x=surface_x,
+            surface_mask=surface_mask,
+            volume_x=volume_x,
+            volume_mask=volume_mask,
+        )
+        out_moe = moe(
+            surface_x=surface_x,
+            surface_mask=surface_mask,
+            volume_x=volume_x,
+            volume_mask=volume_mask,
+        )
+
+    diff_surf = (out_base["surface_preds"] - out_moe["surface_preds"]).abs().max().item()
+    diff_vol = (out_base["volume_preds"] - out_moe["volume_preds"]).abs().max().item()
+    print(f"max |Δ surface_preds| = {diff_surf:.3e}")
+    print(f"max |Δ volume_preds|  = {diff_vol:.3e}")
+    assert "moe_probs" in out_moe and "moe_probs" not in out_base
+    print(f"moe_probs shape       = {tuple(out_moe['moe_probs'].shape)}")
+    # Router probs must be softmax over experts.
+    p_sum = out_moe["moe_probs"].sum(dim=-1)
+    print(f"router probs sum→1?   max|sum−1| = {(p_sum - 1.0).abs().max().item():.3e}")
+
+    ok = diff_surf < 1e-6 and diff_vol < 1e-6
+    print("STEP-0 INVARIANT:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/train.py
+++ b/train.py
@@ -25,6 +25,7 @@ from typing import Iterable
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+import torch.nn.functional as F
 import wandb
 import yaml
 from torch.nn.parallel import DistributedDataParallel
@@ -146,6 +147,10 @@ class Config:
     epochs_already_done: int = 0
     save_every_epoch: bool = False
     debug: bool = False
+    # H363: Physics-regime mixture-of-experts surface decoder.
+    moe_surface_decoder: bool = False
+    moe_num_experts: int = 2
+    moe_aux_loss_weight: float = 0.01
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -271,6 +276,29 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "H244: save EMA checkpoint as 'checkpoint_ep{N}.pt' alongside "
             "the best-only checkpoint after every validation event. Used "
             "to keep EP14/15/16 EMA checkpoints for downstream TTA eval."
+        ),
+        "moe_surface_decoder": (
+            "H363: Enable a physics-regime mixture-of-experts surface "
+            "decoder. Adds a residual ``soft_mixture(experts(h))`` on top "
+            "of the existing surface head; expert output Linears are "
+            "zero-initialised so the residual is exactly zero at init "
+            "(step-0 prediction matches the resumed checkpoint). A small "
+            "linear router maps each surface token's hidden state to a "
+            "softmax over ``--moe-num-experts`` experts. Switch-Transformer "
+            "load-balance auxiliary loss is added with weight "
+            "``--moe-aux-loss-weight``."
+        ),
+        "moe_num_experts": (
+            "H363: Number of mixture experts when --moe-surface-decoder is "
+            "set. Arm A uses 2, Arm B uses 4. Each expert is a 2-layer MLP."
+        ),
+        "moe_aux_loss_weight": (
+            "H363: Weight on the Switch-Transformer load-balance auxiliary "
+            "loss (Fedus et al. 2022): "
+            "``L_aux = N * sum_i (f_i * P_i)`` where ``f_i`` is the fraction "
+            "of tokens routed to expert i (argmax) and ``P_i`` is the mean "
+            "router probability for expert i. Default 0.01 matches the "
+            "original Switch-Transformer recipe."
         ),
     }
     for field in fields(Config):
@@ -429,7 +457,74 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
         drop_path_max=config.drop_path_max,
+        moe_surface_decoder=config.moe_surface_decoder,
+        moe_num_experts=config.moe_num_experts,
     )
+
+
+def moe_router_stats(
+    probs: torch.Tensor,
+    mask: torch.Tensor,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Switch-Transformer load-balance auxiliary loss + router diagnostics.
+
+    Parameters
+    ----------
+    probs:
+        Router probabilities ``[B, N, E]`` (after softmax).
+    mask:
+        Surface-token mask ``[B, N]`` (1.0 for real tokens, 0.0 for padding).
+        Padded positions are ignored everywhere.
+
+    Returns
+    -------
+    L_aux:
+        Differentiable scalar load-balance auxiliary loss.
+    stats:
+        Float diagnostics: per-expert fraction f_i (argmax), per-expert mean
+        router prob P_i, router entropy (mean over tokens of -sum_i p log p),
+        and load-balance ratio max(f) / min(f).
+    """
+
+    if probs is None or mask is None:
+        empty: dict[str, float] = {}
+        return probs.new_zeros(()) if probs is not None else mask.new_zeros(()), empty
+
+    probs_f = probs.float()
+    mask_f = mask.to(dtype=probs_f.dtype, device=probs_f.device)
+    num_experts = probs_f.shape[-1]
+    token_mask = mask_f.unsqueeze(-1)  # [B, N, 1]
+    valid_token_count = mask_f.sum().clamp(min=1.0)
+
+    # Hard-routing fraction f_i: argmax assignment, masked, normalised by
+    # the count of real (non-padding) tokens.
+    argmax_idx = probs_f.argmax(dim=-1)  # [B, N]
+    one_hot = F.one_hot(argmax_idx, num_classes=num_experts).to(probs_f.dtype)  # [B, N, E]
+    f_frac = (one_hot * token_mask).sum(dim=(0, 1)) / valid_token_count  # [E]
+
+    # Soft router-prob P_i averaged over real tokens.
+    P_i = (probs_f * token_mask).sum(dim=(0, 1)) / valid_token_count  # [E]
+
+    # Switch-Transformer aux loss (Fedus et al. 2022).
+    L_aux = float(num_experts) * (f_frac * P_i).sum()
+
+    # Diagnostics (detached).
+    log_probs = torch.log(probs_f.clamp(min=1e-12))
+    per_token_entropy = -(probs_f * log_probs).sum(dim=-1)  # [B, N]
+    mean_entropy = (per_token_entropy * mask_f).sum() / valid_token_count
+    f_frac_min = f_frac.min().clamp(min=1e-12)
+    load_balance_ratio = f_frac.max() / f_frac_min
+
+    stats: dict[str, float] = {
+        "router/mean_entropy": float(mean_entropy.detach().cpu().item()),
+        "router/load_balance_ratio": float(load_balance_ratio.detach().cpu().item()),
+    }
+    f_frac_cpu = f_frac.detach().cpu().tolist()
+    P_i_cpu = P_i.detach().cpu().tolist()
+    for i in range(num_experts):
+        stats[f"router/f_frac_{i}"] = float(f_frac_cpu[i])
+        stats[f"router/P_i_{i}"] = float(P_i_cpu[i])
+    return L_aux, stats
 
 
 def train_loss(
@@ -442,6 +537,7 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    moe_aux_loss_weight: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
@@ -467,13 +563,27 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+        moe_metrics: dict[str, float] = {}
+        moe_aux_loss_value = 0.0
+        moe_aux_weighted_value = 0.0
+        if "moe_probs" in out and moe_aux_loss_weight > 0.0:
+            L_aux, moe_metrics = moe_router_stats(out["moe_probs"], batch.surface_mask)
+            moe_aux_loss_value = float(L_aux.detach().cpu().item())
+            weighted_aux = moe_aux_loss_weight * L_aux
+            moe_aux_weighted_value = float(weighted_aux.detach().cpu().item())
+            loss = loss + weighted_aux
+    metrics: dict[str, float] = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    if moe_metrics:
+        metrics.update(moe_metrics)
+        metrics["moe/aux_loss"] = moe_aux_loss_value
+        metrics["moe/aux_loss_weighted"] = moe_aux_weighted_value
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -942,7 +1052,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.moe_surface_decoder:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)
@@ -1081,6 +1191,15 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["mirror_augmentation"] = config.mirror_augmentation
             wandb.summary["epochs_already_done"] = config.epochs_already_done
             wandb.summary["save_every_epoch"] = config.save_every_epoch
+            wandb.summary["moe/surface_decoder"] = config.moe_surface_decoder
+            wandb.summary["moe/num_experts"] = config.moe_num_experts
+            wandb.summary["moe/aux_loss_weight"] = config.moe_aux_loss_weight
+            if config.moe_surface_decoder:
+                print(
+                    f"H363 MoE surface decoder ENABLED: num_experts="
+                    f"{config.moe_num_experts}, aux_loss_weight="
+                    f"{config.moe_aux_loss_weight}"
+                )
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1230,6 +1349,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        moe_aux_loss_weight=(
+                            config.moe_aux_loss_weight if config.moe_surface_decoder else 0.0
+                        ),
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1270,6 +1392,9 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    for key, value in batch_loss_metrics.items():
+                        if key.startswith("router/") or key.startswith("moe/"):
+                            train_log[f"train/{key}"] = value
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**Physics-regime mixture-of-experts surface WSS decoder (Morgan P4 directive).**

Eleven closed decoder- and loss-side axes (loss-reweight × 3, TTA-saturation × 3, SAM, target-transform × 2, FiLM-decoder × 2, NGSB encoder-routing, BL-derivative-decoder, PCGrad, curvature features, SP-loss-reweight, GeoTransolver content embedding) all converge on one diagnosis: the WSS_z floor at 8.62% (val_cal) / 8.4-9.1% (val_raw) is a **representational** problem, not a gradient-budget or loss-shape problem. The current surface decoder is a single linear projection applied identically to every surface point regardless of aerodynamic regime. Yet DrivAerML surfaces contain at least four geometrically and dynamically distinct flow regimes — smooth attached BL (hood/roof), adverse-pressure-gradient separation (rear slant), wheel-arch/underbody turbulence, sharp trailing edge wake. A single shared head cannot simultaneously specialize for all four.

**Mechanism**: Replace the shared WSS output head with a soft mixture of N=2 expert MLPs (scalable to 4 in Arm B). An entropy-regularized router (1 linear layer `hidden→N` + softmax) allocates each surface token's hidden state across the experts. Zero-init expert output linear layers preserves the step-0 invariant from the EP13 checkpoint. A switch-transformer load-balance auxiliary loss prevents expert collapse.

This is **orthogonal** to all 7 in-flight directions:
- H358/frieren: tangent-basis residual on existing single head (output-basis change)
- H359/askeladd: multi-scale kNN before Transolver slicing (encoder-input)
- H360/fern: LapPE-32 spectral PE (encoder-input)
- H361/edward: cosine+relnorm loss on single head (loss structure)
- H347/nezuko: physical constraint reg on normals
- H352/thorfinn: SWA weight averaging
- H356/alphonse: TTA output averaging

None change **decoder capacity allocation**. H363 is the only experiment testing whether heterogeneous decoder capacity — not uniform representation — is the WSS_z floor.

## Instructions

### Step 1 — Implement `MoESurfaceDecoder` in `model.py`

Replace the current WSS surface output projection (`self.surface_out` or equivalent in your model) with a new `MoESurfaceDecoder` module:

```python
class MoESurfaceDecoder(nn.Module):
    def __init__(self, hidden_dim, out_dim=3, num_experts=2, expert_hidden=None):
        super().__init__()
        self.num_experts = num_experts
        expert_hidden = expert_hidden or (hidden_dim // 2)
        self.experts = nn.ModuleList([
            nn.Sequential(
                nn.Linear(hidden_dim, expert_hidden),
                nn.GELU(),
                nn.Linear(expert_hidden, out_dim),
            ) for _ in range(num_experts)
        ])
        # Zero-init expert output linear layers for step-0 invariance
        for e in self.experts:
            nn.init.zeros_(e[-1].weight)
            nn.init.zeros_(e[-1].bias)
        self.router = nn.Linear(hidden_dim, num_experts)
        # Stable router init
        nn.init.normal_(self.router.weight, std=0.01)
        nn.init.zeros_(self.router.bias)

    def forward(self, h):
        # h: (B, N, D) or (B*N, D)
        logits = self.router(h)              # (..., num_experts)
        probs = F.softmax(logits, dim=-1)    # (..., num_experts)
        expert_outputs = torch.stack([e(h) for e in self.experts], dim=-2)
        # expert_outputs: (..., num_experts, out_dim)
        out = (probs.unsqueeze(-1) * expert_outputs).sum(dim=-2)
        return out, probs
```

Gate behind a CLI flag `--moe_surface_decoder` (or `--moe-surface-decoder` matching project convention). When the flag is enabled, instantiate `MoESurfaceDecoder` with `num_experts = args.moe_num_experts` instead of the existing surface output head.

### Step 2 — Auxiliary load-balance loss

In the training step, add after the main loss:

```python
# probs: (B*N, num_experts) — from MoE forward
f = probs.argmax(dim=-1)
N = probs.size(-1)
f_frac = torch.stack([(f == i).float().mean() for i in range(N)])  # fraction routed to each
P = probs.mean(dim=0)  # mean router prob per expert
L_aux = N * (f_frac * P).sum()  # switch-transformer formulation
loss = loss_main + args.moe_aux_loss_weight * L_aux
```

Also log to W&B: `router/mean_entropy` (mean over batch of `-Σ p log p`), `router/load_balance_ratio` (`max(f_frac)/min(f_frac)`), and per-expert routing fractions.

### Step 3 — CLI flags to add

```
--moe_surface_decoder         # bool, default False
--moe_num_experts             # int, default 2
--moe_aux_loss_weight         # float, default 0.01
```

### Step 4 — Smoke (5-10 min, 1 partial epoch)

```bash
SENPAI_TIMEOUT_MINUTES=30 SENPAI_MAX_EPOCHS=1 \
torchrun --nproc_per_node=8 train.py \
  --epochs 14 --epochs_already_done 13 \
  --agent tanjiro \
  --wandb_name "tanjiro/h363-smoke" \
  --wandb_group h363-regime-moe \
  --resume_from_wandb yw2a5dyl --resume_alias epoch-13 \
  --checkpoint_strict_load false \
  --lr 1e-4 --lr_cosine_t_max 3 --lr_min 1e-6 \
  --tau_z_loss_weight 1.67 \
  --surface_loss_weight 2.0 --volume_loss_weight 0.5 \
  --moe_surface_decoder --moe_num_experts 2 --moe_aux_loss_weight 0.01 \
  --use_surf_to_vol_xattn --enable_residual_positions \
  --use_drop_path --drop_path_rate 0.10 \
  --ema_decay 0.999 --grad_clip 1.0 \
  --kill-thresholds "500:train/loss<5,2000:val_primary/abupt_axis_mean_rel_l2_pct<25"
```

**Smoke gate**: step-0 `val_primary/abupt_axis_mean_rel_l2_pct` within 0.01% of EP13 base value (step-0 invariant from zero-init); train loss < 1.0 within 50 steps. If step-0 differs from EP13 → implementation bug (zero-init failed) → close.

### Step 5 — Phase 1 Arm A: N=2 experts, 3 cosine-tail epochs (~7h)

```bash
SENPAI_TIMEOUT_MINUTES=540 SENPAI_MAX_EPOCHS=3 \
torchrun --nproc_per_node=8 train.py \
  --epochs 16 --epochs_already_done 13 \
  --agent tanjiro \
  --wandb_name "tanjiro/h363-armA-N2" \
  --wandb_group h363-regime-moe \
  --resume_from_wandb yw2a5dyl --resume_alias epoch-13 \
  --checkpoint_strict_load false \
  --lr 1e-4 --lr_cosine_t_max 3 --lr_min 1e-6 \
  --tau_z_loss_weight 1.67 \
  --surface_loss_weight 2.0 --volume_loss_weight 0.5 \
  --moe_surface_decoder --moe_num_experts 2 --moe_aux_loss_weight 0.01 \
  --use_surf_to_vol_xattn --enable_residual_positions \
  --use_drop_path --drop_path_rate 0.10 \
  --ema_decay 0.999 --grad_clip 1.0 --save_best_checkpoint
```

**Phase 1 gate**: `val_abupt_axis_mean_rel_l2_pct_raw < 6.05%` (tanjiro H357 reference 6.0065%, target an improvement of ≥1bp raw or better).

### Step 6 — Phase 1 Arm B (conditional): N=4 experts

Only if Arm A passes the gate OR Arm A val ∈ [6.05%, 6.10%] with healthy router (entropy H > 0.5 nats, load_ratio < 3×):

```bash
# same as Arm A with --moe_num_experts 4 and --wandb_name "tanjiro/h363-armB-N4"
```

### Step 7 — TTA Phase 2 (if Phase 1 winner)

```bash
torchrun --nproc_per_node=8 eval_tta_h252.py \
  --checkpoint outputs/drivaerml/run-<H363-run-id>/checkpoint_best.pt \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 5 --antithetic-noise \
  --weight-noise-dist student_t --weight-noise-df 4 \
  --test-time-calibration \
  --wandb_group h363-regime-moe
```

### Param overhead

With hidden_dim=512: router 512×2=1024 params; each expert MLP 512×256+256+256×3+3 ≈ 132k. One extra expert = ~132k params over baseline (~50M total) = **~0.26%**. Well within ≤+1% cap.

### Expert collapse diagnostic

Report at end of Arm A:
- `router/mean_entropy` (averaged over batches and tokens; healthy ≥0.5 nats; collapsed <0.05 nats)
- `router/load_balance_ratio` (`max(f_frac)/min(f_frac)`; healthy <3×; collapsed >10×)
- per-expert routing distribution across val set (which surfaces does expert_0 vs expert_1 prefer?)

## Baseline

Current SOTA: **H342** 3-cp output-avg PR #1526 MERGED 2026-06-01.
- val_cal: 5.8962% | test_cal: 5.7357% | test_WSS_z: 8.6122% | test_VP: 3.421% | test_SP: 3.577%
- Baseline W&B runs: `3icmxaqe` (ep13 TTA), `qgw0ix77` (ep14 TTA), `ijadzof0` (ep15 TTA)
- EP13 checkpoint: `yw2a5dyl --resume_alias epoch-13`

Tanjiro H357 raw reference: `val_abupt_raw 6.0065 / test_raw 5.8539 / WSS_z 9.18 raw`.

**Morgan target**: test_WSS_z < 5.85% (Transolver-3 SOTA), no test_VP regression beyond 3.421%, no test_SP regression beyond 3.577%. **AND-gate** logic on val_cal+test_cal.

## Pre-committed close rules

- Smoke step-0 val ≠ EP13 baseline → close (implementation bug, zero-init failed)
- Phase 1 Arm A `val_abupt_raw > 6.10%` → close (mechanism null)
- Phase 1 Arm A router entropy < 0.05 nats AND val_raw > 6.05% → close (expert collapse, mechanism degenerated)
- Phase 1 Arm A val ∈ [6.05%, 6.10%] + healthy router (H > 0.5, load <3×) → escalate to Arm B (N=4)
- Phase 1 Arm A val < 6.05% AND healthy router → TTA cascade, then merge eval against SOTA AND-gate

## Backup hypotheses (next-tier if H363 nulls)

**B1 — Hierarchical coarse-to-fine attention bias**: precompute surface kNN (k=32) proximity mask, inject as additive attention bias INTO Transolver slice-attention (before softmax). Zero extra params. Different from H359 askeladd (kNN as encoder feature branch).

**B2 — BL-thickness modulated loss weighting**: estimate local boundary-layer thickness δ(x) from SDF volume grid, set per-point training loss weight `w(x) ∝ δ(x)^{-0.5}`. Different from closed loss-reweight axes (H339/H341/H346) which used uniform per-channel or per-vertex weighting.

## Expected wall time

Smoke 5-15 min + Arm A 7h + (conditional Arm B 7h) + TTA 6h ≈ 14-21h total.
