### PR TITLE
H364: Target-magnitude top-decile WSS hotspot reweighting

### DIFF
--- a/train.py
+++ b/train.py
@@ -57,6 +57,7 @@ from trainer_runtime import (
     masked_mse,
     metric_namespace,
     weighted_channel_mse,
+    weighted_per_point_channel_mse,
     parse_kill_thresholds,
     primary_metric_log,
     print_metrics,
@@ -106,6 +107,9 @@ class Config:
     drop_path_max: float = 0.0
     tau_y_loss_weight: float = 1.0
     tau_z_loss_weight: float = 1.0
+    wss_hotspot_gamma: float = 1.0
+    wss_hotspot_quantile: float = 0.90
+    max_steps: int = 0
     amp_mode: str = "bf16"
     num_workers: int = -1
     pin_memory: bool = True
@@ -272,6 +276,27 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "the best-only checkpoint after every validation event. Used "
             "to keep EP14/15/16 EMA checkpoints for downstream TTA eval."
         ),
+        "wss_hotspot_gamma": (
+            "H364: static per-point reweighting for top-decile WSS hotspots. "
+            "Surface points whose denormalized ||target_wss|| is at or above "
+            "the wss_hotspot_quantile of the in-batch distribution receive "
+            "this multiplicative weight (applied only to WSS channel MSE "
+            "terms, i.e. tau_x/tau_y/tau_z; cp and volume_pressure are left "
+            "unchanged). 1.0 disables the reweight (default; identical to "
+            "the legacy weighted_channel_mse path)."
+        ),
+        "wss_hotspot_quantile": (
+            "H364: quantile threshold used to define top-decile WSS hotspots "
+            "for --wss-hotspot-gamma reweighting. Computed per-batch over "
+            "valid (unmasked) surface points using ||target_wss|| in "
+            "physical (denormalized) space. Default 0.90 selects the top "
+            "10% of points by WSS magnitude."
+        ),
+        "max_steps": (
+            "Optional cap on total optimizer steps. 0 (default) disables. "
+            "Used for smoke tests: training breaks out of the epoch loop "
+            "once global_step >= max_steps, before validation."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -432,6 +457,71 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+WSS_CHANNEL_INDICES = (1, 2, 3)
+
+
+def compute_wss_hotspot_weight(
+    surface_target_normalized: torch.Tensor,
+    surface_mask: torch.Tensor,
+    transform: TargetTransform,
+    gamma: float,
+    quantile: float,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Compute the per-point WSS hotspot multiplicative weight tensor.
+
+    H364: top-decile by physical (denormalized) ``||target_wss||`` receive
+    weight ``gamma`` (applied to WSS channels only); other valid points and
+    padded entries receive weight ``1.0``. The quantile is computed per-batch
+    over valid surface points; per-rank batches are independent but the WSS
+    magnitude distribution is dense enough that local q90 is a stable
+    estimator without a cross-rank reduce.
+
+    Returns ``(point_weight_bn, diagnostics)`` where ``point_weight_bn`` has
+    shape ``[B, N]`` and ``diagnostics`` reports the threshold, the hotspot
+    fraction, and the mean ||WSS|| inside/outside the mask. Computed in
+    float32 outside autocast so the quantile is numerically stable.
+    """
+    target = surface_target_normalized.detach().float()
+    mask_bool = surface_mask.detach().bool()
+    surface_y_std = transform.surface_y_std.to(target.device).float()
+    surface_y_mean = transform.surface_y_mean.to(target.device).float()
+    wss_indices = torch.tensor(
+        list(WSS_CHANNEL_INDICES), device=target.device, dtype=torch.long
+    )
+    wss_target_norm = target.index_select(-1, wss_indices)
+    wss_std = surface_y_std.index_select(-1, wss_indices)
+    wss_mean = surface_y_mean.index_select(-1, wss_indices)
+    wss_target_unnorm = wss_target_norm * wss_std + wss_mean
+    wss_norm = wss_target_unnorm.norm(dim=-1)
+    flat = wss_norm[mask_bool]
+    if flat.numel() > 0:
+        threshold = torch.quantile(flat, quantile)
+    else:
+        threshold = torch.zeros((), device=target.device, dtype=torch.float32)
+    hotspot = (wss_norm >= threshold) & mask_bool
+    point_weight = torch.where(
+        hotspot,
+        torch.full_like(wss_norm, float(gamma)),
+        torch.ones_like(wss_norm),
+    )
+    valid_count = mask_bool.sum().clamp_min(1)
+    hotspot_count = hotspot.sum()
+    hotspot_norm_sum = (wss_norm * hotspot.float()).sum()
+    cold_count = (mask_bool & ~hotspot).sum().clamp_min(1)
+    cold_norm_sum = (wss_norm * (mask_bool & ~hotspot).float()).sum()
+    diagnostics = {
+        "wss_hotspot/threshold": float(threshold.item()),
+        "wss_hotspot/fraction": float((hotspot_count.float() / valid_count.float()).item()),
+        "wss_hotspot/mean_norm_in": float(
+            (hotspot_norm_sum / hotspot_count.clamp_min(1).float()).item()
+        ),
+        "wss_hotspot/mean_norm_out": float(
+            (cold_norm_sum / cold_count.float()).item()
+        ),
+    }
+    return point_weight, diagnostics
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -442,10 +532,22 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    wss_hotspot_gamma: float = 1.0,
+    wss_hotspot_quantile: float = 0.90,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    hotspot_diagnostics: dict[str, float] = {}
+    hotspot_point_weight: torch.Tensor | None = None
+    if wss_hotspot_gamma != 1.0:
+        hotspot_point_weight, hotspot_diagnostics = compute_wss_hotspot_weight(
+            surface_target,
+            batch.surface_mask,
+            transform,
+            gamma=wss_hotspot_gamma,
+            quantile=wss_hotspot_quantile,
+        )
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -453,7 +555,45 @@ def train_loss(
             volume_x=batch.volume_x,
             volume_mask=batch.volume_mask,
         )
-        if surface_channel_weights is not None:
+        if hotspot_point_weight is not None:
+            channel_weights = (
+                surface_channel_weights
+                if surface_channel_weights is not None
+                else torch.ones(
+                    surface_target.shape[-1],
+                    device=surface_target.device,
+                    dtype=surface_target.dtype,
+                )
+            )
+            channel_weights = channel_weights.to(
+                device=surface_target.device, dtype=surface_target.dtype
+            )
+            point_weight = hotspot_point_weight.to(
+                device=surface_target.device, dtype=surface_target.dtype
+            )
+            # Build per-(B, N, C) weight tensor: WSS channels get
+            # channel_weight × hotspot_point_weight; non-WSS channels (cp at
+            # index 0) get channel_weight × 1.0.
+            per_channel_point = point_weight.unsqueeze(-1).expand(
+                -1, -1, surface_target.shape[-1]
+            ).clone()
+            non_wss = [
+                c for c in range(surface_target.shape[-1])
+                if c not in WSS_CHANNEL_INDICES
+            ]
+            if non_wss:
+                non_wss_idx = torch.tensor(
+                    non_wss, device=per_channel_point.device, dtype=torch.long
+                )
+                per_channel_point.index_fill_(-1, non_wss_idx, 1.0)
+            bnc_weights = per_channel_point * channel_weights
+            surface_loss = weighted_per_point_channel_mse(
+                out["surface_preds"],
+                surface_target,
+                batch.surface_mask,
+                bnc_weights,
+            )
+        elif surface_channel_weights is not None:
             surface_loss = weighted_channel_mse(
                 out["surface_preds"],
                 surface_target,
@@ -467,13 +607,15 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    diagnostics: dict[str, float] = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    diagnostics.update(hotspot_diagnostics)
+    return loss, diagnostics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -1033,6 +1175,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     f"Surface channel weights: cp=1.0 tau_x=1.0 "
                     f"tau_y={config.tau_y_loss_weight} tau_z={config.tau_z_loss_weight}"
                 )
+            if config.wss_hotspot_gamma != 1.0:
+                print(
+                    f"H364 WSS hotspot reweight: gamma={config.wss_hotspot_gamma} "
+                    f"quantile={config.wss_hotspot_quantile} "
+                    f"(applies only to WSS channels tau_x/tau_y/tau_z)"
+                )
 
         run = init_wandb_run(
             config=config,
@@ -1064,6 +1212,8 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["model/string_sep_init_sigmas"] = init_sigmas_for_log
             wandb.summary["loss/tau_y_loss_weight"] = config.tau_y_loss_weight
             wandb.summary["loss/tau_z_loss_weight"] = config.tau_z_loss_weight
+            wandb.summary["loss/wss_hotspot_gamma"] = config.wss_hotspot_gamma
+            wandb.summary["loss/wss_hotspot_quantile"] = config.wss_hotspot_quantile
             backbone = getattr(base_model, "backbone", None)
             if backbone is not None and hasattr(backbone, "blocks"):
                 drop_path_schedule = [
@@ -1230,6 +1380,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        wss_hotspot_gamma=config.wss_hotspot_gamma,
+                        wss_hotspot_quantile=config.wss_hotspot_quantile,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1268,8 +1420,18 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                             "train/tau_y_loss_weight": config.tau_y_loss_weight,
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
+                            "train/wss_hotspot_gamma": config.wss_hotspot_gamma,
+                            "train/wss_hotspot_quantile": config.wss_hotspot_quantile,
                         }
                     )
+                    for key in (
+                        "wss_hotspot/threshold",
+                        "wss_hotspot/fraction",
+                        "wss_hotspot/mean_norm_in",
+                        "wss_hotspot/mean_norm_out",
+                    ):
+                        if key in batch_loss_metrics:
+                            train_log[f"train/{key}"] = batch_loss_metrics[key]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 
@@ -1362,6 +1524,14 @@ def main(argv: Iterable[str] | None = None) -> None:
                             f"Train timeout ({train_timeout_minutes:.1f} min) mid-epoch "
                             f"at step {global_step}. Forcing validation and stopping."
                         )
+                    break
+                if config.max_steps > 0 and global_step >= config.max_steps:
+                    if state.is_main:
+                        print(
+                            f"max_steps reached ({global_step} >= {config.max_steps}). "
+                            "Stopping training loop for smoke test."
+                        )
+                    timeout_hit = True
                     break
 
             scheduler.step()

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -874,6 +874,38 @@ def weighted_channel_mse(
     return pred.sum() * 0.0
 
 
+def weighted_per_point_channel_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+    weights_bnc: torch.Tensor,
+) -> torch.Tensor:
+    """Per-(B, N, C) weighted masked MSE with a single mean over all entries.
+
+    Generalization of :func:`weighted_channel_mse`: the weights tensor has
+    shape [B, N, C] so each (sample, point, channel) entry can have its own
+    multiplicative weight. Used for H364 to combine per-channel WSS weights
+    with per-point top-decile hotspot reweighting in a single MSE pass.
+    Divides by (valid_points × num_channels) so that under unit weights the
+    loss matches :func:`masked_mse` exactly.
+    """
+    if pred.numel() == 0:
+        return pred.sum() * 0.0
+    if weights_bnc.shape != pred.shape:
+        raise ValueError(
+            f"weights_bnc shape {weights_bnc.shape} must match pred shape {pred.shape}"
+        )
+    weights_dev = weights_bnc.to(device=pred.device, dtype=pred.dtype)
+    sq_err = (pred - target).square()
+    mask_dev = mask.to(device=pred.device, dtype=pred.dtype).unsqueeze(-1)
+    weighted = sq_err * weights_dev * mask_dev
+    valid_points = mask_dev.sum()
+    denominator = (valid_points * pred.shape[-1]).clamp_min(1.0)
+    if bool(valid_points.detach().cpu().item() > 0):
+        return weighted.sum() / denominator
+    return pred.sum() * 0.0
+
+
 def squared_relative_l2_loss(
     pred: torch.Tensor,
     target: torch.Tensor,


### PR DESCRIPTION
## Hypothesis

**H364: Target-magnitude top-decile WSS hotspot reweighting** — up-weight surface points in the top decile of `||target_wss||` (norm of the true WSS vector) to focus gradient mass on vortex-shedding regions (wheel arches, A-pillar, mirror wakes) where WSS magnitude is highest and rel_l2 error is driven.

**Why this is structurally different from all closed scalar-reweight axes:**
- H339 (uniform WSS channel reweight): same weight at every surface point
- H341 (wz-only channel reweight): per-channel not per-point
- H346 (per-vertex focal EMA): dynamic weight conditioned on *historical prediction error*, not target magnitude

H364 uses a **static, target-conditioned per-point weight**: points with `||target_wss||` in top decile get `w=γ`, others get `w=1`. This explicitly concentrates gradient mass on the *physically meaningful high-WSS zones* — the same vortex-shedding hotspots that determine whether WSS_z improves.

**Discriminator context**: H361 (direction-magnitude decomposed loss) confirmed that the bottleneck is representation, not loss geometry. H364 asks whether the bottleneck is specifically *gradient mass concentration* — the current per-channel MSE distributes gradient equally across all surface points, including low-WSS background. If high-WSS hotspots need more representation capacity, up-weighting them at training time concentrates capacity there.

**Expected outcome**: Either (a) WSS_z improves, revealing gradient allocation is a key bottleneck, or (b) null/regression, confirming the bottleneck is representation depth/architecture (consistent with H361's discriminator).

**Two arms to screen**: γ=3 (Arm A) and γ=5 (Arm B), each 3-epoch cosine-tail fine-tune from H336 EP13 checkpoint. Arm B conditional on Arm A val_raw passing the close rule.

## Instructions

### Environment
All runs: DDP 8 GPUs via `torchrun --nproc_per_node=8`

### Step 1 — Implement per-point target-magnitude weight in `train.py`

In `train.py`, locate the surface loss computation. Add a static per-point weight mask based on the norm of the true WSS vector target. Apply this weight to the per-point MSE terms for WSS channels only (do not weight SP or VP predictions).

**Concrete implementation:**

```python
# In the surface loss block (where you compute per-point WSS MSE):
# Compute target WSS norm across all 3 channels
target_wss = target_surface[..., wss_channel_indices]  # shape (B, N, 3) or (N, 3)
target_wss_norm = torch.norm(target_wss, dim=-1)  # shape (B, N) or (N,)

# Compute top-decile threshold (90th percentile of ||target_wss|| in the batch)
threshold = torch.quantile(target_wss_norm.reshape(-1), 0.90)

# Build per-point weight
hotspot_weight = torch.where(target_wss_norm >= threshold,
                              torch.full_like(target_wss_norm, wss_hotspot_gamma),
                              torch.ones_like(target_wss_norm))

# Apply to WSS per-point MSE: multiply each point's squared error by hotspot_weight
# e.g. loss_wss_per_point = (pred_wss - target_wss).pow(2)  # shape (B, N, 3) or (N, 3)
# weighted_loss_wss = (loss_wss_per_point * hotspot_weight.unsqueeze(-1)).mean()
```

Add a CLI flag `--wss_hotspot_gamma` (default 1.0 = disabled). Use `--wss_hotspot_gamma 3.0` for Arm A and `--wss_hotspot_gamma 5.0` for Arm B.

**Important**: Log `wss_hotspot_gamma` to W&B config. Do NOT touch `tau_z_loss_weight` (locked at 1.67). Do NOT touch data loaders or protected files.

### Step 2 — Smoke test (2 steps, 2 GPU ranks)

```bash
SENPAI_MAX_EPOCHS=14 torchrun --standalone --nproc_per_node=2 train.py \
  --epochs 14 --epochs_already_done 13 \
  --resume_from_wandb yw2a5dyl --resume_alias epoch-13 \
  --lr 1e-4 --lr_cosine_t_max 3 --lr_min 1e-6 \
  --tau_z_loss_weight 1.67 \
  --wss_hotspot_gamma 3.0 \
  --wandb_group h364-wss-hotspot-reweight \
  --wandb_name "edward/h364-smoke" \
  --max_steps 30
```

Confirm train/loss decreases normally (should look like H336 fine-tune, ~0.015-0.020 at step 30).

### Step 3 — Arm A: γ=3 (8 GPUs, 3-epoch cosine-tail fine-tune)

**Pre-committed close rule**: If EP14 val_primary/abupt_axis_mean_rel_l2_pct > 6.05%, close immediately (same rule as H361/H358 — prevents wasting eval time on clear regressions).

```bash
SENPAI_MAX_EPOCHS=16 SENPAI_TIMEOUT_MINUTES=540 \
torchrun --standalone --nproc_per_node=8 train.py \
  --epochs 16 --epochs_already_done 13 \
  --resume_from_wandb yw2a5dyl --resume_alias epoch-13 \
  --lr 1e-4 --lr_cosine_t_max 3 --lr_min 1e-6 \
  --tau_z_loss_weight 1.67 \
  --wss_hotspot_gamma 3.0 \
  --wandb_group h364-wss-hotspot-reweight \
  --wandb_name "edward/h364-armA-gamma3"
```

### Step 4 — Arm A Phase 2: val close-rule check

After EP16 val:
- If val_primary abupt > 5.98%: apply the EP16 close rule — report results and stop (skip Arm B, skip TTA)
- If val_primary abupt ≤ 5.98%: proceed to Arm B

If Phase 1 val passes close rules, launch TTA eval using **H342 recipe** (K=5 × Student-t ν=4 × 8-res × mirror × antithetic) — same as the current SOTA recipe. The TTA eval chain should mirror what alphonse did for H356 (3-checkpoint output-space average of EP13+EP14+EP15, then K=5 TTA).

### Step 5 — Arm B: γ=5 (conditional on Arm A passing close rule)

**Only run if Arm A val_primary EP16 ≤ 5.98%.**

```bash
SENPAI_MAX_EPOCHS=16 SENPAI_TIMEOUT_MINUTES=540 \
torchrun --standalone --nproc_per_node=8 train.py \
  --epochs 16 --epochs_already_done 13 \
  --resume_from_wandb yw2a5dyl --resume_alias epoch-13 \
  --lr 1e-4 --lr_cosine_t_max 3 --lr_min 1e-6 \
  --tau_z_loss_weight 1.67 \
  --wss_hotspot_gamma 5.0 \
  --wandb_group h364-wss-hotspot-reweight \
  --wandb_name "edward/h364-armB-gamma5"
```

## Baseline

Current SOTA: **H342 PR #1526** (3-cp output-average × H336 TTA recipe)
- **val_abupt_calibrated = 5.8962%** (gate: must beat this)
- **test_abupt_calibrated = 5.7357%** (gate: must beat this)
- AND-logic: both must improve for merge

Per-channel breakdown:
- val_WSS=6.7038%, val_WSS_z=9.0807%, val_SP=3.9064%, val_VP=3.4601%
- test_WSS=6.5963%, test_WSS_z=8.6122%, test_SP=3.5770%, test_VP=3.4218%

Source checkpoint for fine-tuning: **H336 EP13 W&B run `yw2a5dyl`, alias `epoch-13`**

W&B project: `wandb-applied-ai-team/senpai-v1-drivaerml-ddp8`

Reproduce current SOTA:
```bash
cd target/ && torchrun --standalone --nproc_per_node=8 train.py \
  --epochs 16 --epochs_already_done 13 \
  --resume_from_wandb yw2a5dyl --resume_alias epoch-13 \
  --lr 1e-4 --lr_cosine_t_max 3 --lr_min 1e-6 \
  --tau_z_loss_weight 1.67 \
  --wandb_group h342-3cp-output-avg
```
