### PR TITLE
H370 ISAB middle-layer REPLACE — Set Transformer inducing-point attention (non-capacity-additive)

### DIFF
--- a/model.py
+++ b/model.py
@@ -320,6 +320,138 @@ class TransolverAttention(nn.Module):
         return _apply_token_mask(out_x, attn_mask)
 
 
+class ISABTransolverAttention(nn.Module):
+    """H370: Transolver attention with per-head ISAB slice-token mixing.
+
+    Replaces the O(S^2) slice-token self-attention with a Set-Transformer
+    ISAB (Lee et al. ICML 2019) bottlenecked through ``inducing_points``
+    learned per-head latent queries. The slice-token construction
+    (``create_slices``) and the scatter back to mesh points are unchanged
+    from ``TransolverAttention``; only the mixing operator on the slice
+    tokens is swapped.
+
+    Inducing points have shape ``[num_heads, M, dim_head]`` so each head
+    owns its own bottleneck manifold. The two MABs use post-LN with a
+    minimal per-head FFN (``dim_head -> dim_head -> dim_head``) to keep
+    the parameter overhead small relative to the original ``qkv`` matrix
+    that this operator replaces.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        num_slices: int,
+        inducing_points: int = 32,
+        dropout: float = 0.0,
+        use_qk_norm: bool = False,
+    ):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads")
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.dim_head = hidden_dim // num_heads
+        self.num_slices = num_slices
+        self.num_inducing = inducing_points
+        self.dropout = dropout
+        self.use_qk_norm = use_qk_norm
+
+        # Slice creation (mirrors TransolverAttention).
+        self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
+        self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
+        self.in_project_fx = LinearProjection(hidden_dim, hidden_dim)
+        self.in_project_slice = LinearProjection(self.dim_head, num_slices)
+        # Output projection (mirrors TransolverAttention).
+        self.proj = LinearProjection(hidden_dim, hidden_dim)
+        self.proj_dropout = nn.Dropout(dropout)
+
+        # Per-head inducing points: [H, M, dim_head].
+        self.inducing_points = nn.Parameter(
+            torch.empty(num_heads, self.num_inducing, self.dim_head)
+        )
+        nn.init.trunc_normal_(self.inducing_points, std=0.02)
+
+        # MAB1: I (queries) <- slice_tokens (keys/values).
+        self.mab1_norm_attn = nn.LayerNorm(self.dim_head, eps=1e-6)
+        self.mab1_norm_ffn = nn.LayerNorm(self.dim_head, eps=1e-6)
+        self.mab1_ffn = UpActDownMlp(hidden_dim=self.dim_head, mlp_hidden_dim=self.dim_head)
+
+        # MAB2: slice_tokens (queries) <- H (keys/values).
+        self.mab2_norm_attn = nn.LayerNorm(self.dim_head, eps=1e-6)
+        self.mab2_norm_ffn = nn.LayerNorm(self.dim_head, eps=1e-6)
+        self.mab2_ffn = UpActDownMlp(hidden_dim=self.dim_head, mlp_hidden_dim=self.dim_head)
+
+        if use_qk_norm:
+            self.mab1_q_norm = nn.RMSNorm(self.dim_head, elementwise_affine=True)
+            self.mab1_k_norm = nn.RMSNorm(self.dim_head, elementwise_affine=True)
+            self.mab2_q_norm = nn.RMSNorm(self.dim_head, elementwise_affine=True)
+            self.mab2_k_norm = nn.RMSNorm(self.dim_head, elementwise_affine=True)
+        else:
+            self.mab1_q_norm = None
+            self.mab1_k_norm = None
+            self.mab2_q_norm = None
+            self.mab2_k_norm = None
+
+    def create_slices(
+        self, x: torch.Tensor, attn_mask: torch.Tensor | None = None
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        batch_size, num_tokens, _ = x.shape
+        fx_mid = self.in_project_fx(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
+        x_mid = self.in_project_x(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
+        slice_logits = self.in_project_slice(x_mid) / self.temperature
+        slice_weights = F.softmax(slice_logits, dim=-1)
+        if attn_mask is not None:
+            slice_weights = slice_weights * attn_mask[:, None, :, None].to(
+                device=slice_weights.device,
+                dtype=slice_weights.dtype,
+            )
+        slice_norm = slice_weights.sum(dim=2, keepdim=False).unsqueeze(-1)
+        slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
+        return slice_tokens, slice_weights
+
+    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+        slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
+        batch_size = slice_tokens.shape[0]
+
+        # MAB1: inducing points attend to the S slice tokens.
+        # I_expanded: [B, H, M, dim_head]; slice_tokens: [B, H, S, dim_head].
+        I_expanded = self.inducing_points.unsqueeze(0).expand(batch_size, -1, -1, -1)
+        q1 = I_expanded
+        k1 = slice_tokens
+        v1 = slice_tokens
+        if self.mab1_q_norm is not None:
+            q1 = self.mab1_q_norm(q1)
+            k1 = self.mab1_k_norm(k1)
+        h_attn = F.scaled_dot_product_attention(
+            q1, k1, v1,
+            dropout_p=self.dropout if self.training else 0.0,
+        )
+        h = self.mab1_norm_attn(h_attn + I_expanded)
+        h = self.mab1_norm_ffn(h + self.mab1_ffn(h))
+
+        # MAB2: S slice tokens attend back to the M compressed reps.
+        q2 = slice_tokens
+        k2 = h
+        v2 = h
+        if self.mab2_q_norm is not None:
+            q2 = self.mab2_q_norm(q2)
+            k2 = self.mab2_k_norm(k2)
+        out_attn = F.scaled_dot_product_attention(
+            q2, k2, v2,
+            dropout_p=self.dropout if self.training else 0.0,
+        )
+        out_slice = self.mab2_norm_attn(out_attn + slice_tokens)
+        out_slice = self.mab2_norm_ffn(out_slice + self.mab2_ffn(out_slice))
+
+        # Scatter back to N tokens (mirrors TransolverAttention).
+        out_x = torch.einsum("bhsc,bhns->bhnc", out_slice, slice_weights)
+        out_x = out_x.permute(0, 2, 1, 3).contiguous().view(x.shape[0], x.shape[1], self.hidden_dim)
+        out_x = _apply_token_mask(out_x, attn_mask)
+        out_x = self.proj_dropout(self.proj(out_x))
+        return _apply_token_mask(out_x, attn_mask)
+
+
 class TransformerBlock(nn.Module):
     def __init__(
         self,
@@ -330,17 +462,29 @@ class TransformerBlock(nn.Module):
         dropout: float = 0.0,
         use_qk_norm: bool = False,
         drop_path_prob: float = 0.0,
+        use_isab: bool = False,
+        isab_inducing_points: int = 32,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
         self.norm1 = nn.LayerNorm(hidden_dim, eps=1e-6)
-        self.attention = TransolverAttention(
-            hidden_dim=hidden_dim,
-            num_heads=num_heads,
-            num_slices=num_slices,
-            dropout=dropout,
-            use_qk_norm=use_qk_norm,
-        )
+        if use_isab:
+            self.attention = ISABTransolverAttention(
+                hidden_dim=hidden_dim,
+                num_heads=num_heads,
+                num_slices=num_slices,
+                inducing_points=isab_inducing_points,
+                dropout=dropout,
+                use_qk_norm=use_qk_norm,
+            )
+        else:
+            self.attention = TransolverAttention(
+                hidden_dim=hidden_dim,
+                num_heads=num_heads,
+                num_slices=num_slices,
+                dropout=dropout,
+                use_qk_norm=use_qk_norm,
+            )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
         self.drop_path_attn = DropPath(drop_path_prob)
@@ -366,6 +510,8 @@ class Transformer(nn.Module):
         dropout: float = 0.0,
         use_qk_norm: bool = False,
         drop_path_max: float = 0.0,
+        isab_layer_indices: list[int] | None = None,
+        isab_inducing_points: int = 32,
     ):
         super().__init__()
         if depth > 1:
@@ -373,6 +519,14 @@ class Transformer(nn.Module):
         else:
             drop_path_probs = [0.0]
         self.drop_path_probs = drop_path_probs
+        isab_set = set(isab_layer_indices or [])
+        for idx in isab_set:
+            if not 0 <= idx < depth:
+                raise ValueError(
+                    f"isab_layer_indices entry {idx} is outside [0, {depth})"
+                )
+        self.isab_layer_indices = sorted(isab_set)
+        self.isab_inducing_points = isab_inducing_points
         self.blocks = nn.ModuleList(
             [
                 TransformerBlock(
@@ -383,6 +537,8 @@ class Transformer(nn.Module):
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
                     drop_path_prob=drop_path_probs[i],
+                    use_isab=(i in isab_set),
+                    isab_inducing_points=isab_inducing_points,
                 )
                 for i in range(depth)
             ]
@@ -419,6 +575,8 @@ class SurfaceTransolver(nn.Module):
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
         drop_path_max: float = 0.0,
+        isab_layer_indices: list[int] | None = None,
+        isab_inducing_points: int = 32,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -511,6 +669,8 @@ class SurfaceTransolver(nn.Module):
             dropout=dropout,
             use_qk_norm=use_qk_norm,
             drop_path_max=drop_path_max,
+            isab_layer_indices=isab_layer_indices,
+            isab_inducing_points=isab_inducing_points,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:

--- a/train.py
+++ b/train.py
@@ -145,6 +145,11 @@ class Config:
     resume_alias: str = ""
     epochs_already_done: int = 0
     save_every_epoch: bool = False
+    # H370: ISAB (Set Transformer inducing-point attention) middle-layer
+    # REPLACE. Empty string disables; comma-separated indices select which
+    # backbone block(s) get the ISAB operator (default off for all layers).
+    use_isab_layers: str = ""
+    isab_inducing_points: int = 32
     debug: bool = False
 
 
@@ -271,6 +276,19 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "H244: save EMA checkpoint as 'checkpoint_ep{N}.pt' alongside "
             "the best-only checkpoint after every validation event. Used "
             "to keep EP14/15/16 EMA checkpoints for downstream TTA eval."
+        ),
+        "use_isab_layers": (
+            "H370: comma-separated backbone block indices that should "
+            "REPLACE the O(S^2) slice-token self-attention with a per-head "
+            "ISAB (Set Transformer inducing-point attention, Lee et al. "
+            "ICML 2019) mixer. Empty string disables ISAB everywhere. "
+            "Example: '1,2,3' replaces the middle 3 of a 5-layer stack."
+        ),
+        "isab_inducing_points": (
+            "H370: number of inducing points (M) per head used by ISAB "
+            "blocks when --use-isab-layers is non-empty. Default 32 with "
+            "S=128 slice tokens is a 4x bottleneck. Inducing point tensor "
+            "shape is [num_heads, M, dim_head]."
         ),
     }
     for field in fields(Config):
@@ -414,6 +432,19 @@ def mirror_augment_batch(batch, p: float = 0.5):
     )
 
 
+def parse_isab_layer_indices(spec: str) -> list[int]:
+    spec = (spec or "").strip()
+    if not spec:
+        return []
+    indices = []
+    for piece in spec.split(","):
+        piece = piece.strip()
+        if not piece:
+            continue
+        indices.append(int(piece))
+    return indices
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -429,6 +460,8 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
         drop_path_max=config.drop_path_max,
+        isab_layer_indices=parse_isab_layer_indices(config.use_isab_layers),
+        isab_inducing_points=config.isab_inducing_points,
     )
 
 


### PR DESCRIPTION
## Hypothesis

**H370 — ISAB (Set Transformer Inducing-Point Attention Block) middle-layer REPLACE, non-capacity-additive architectural rewrite.**

Phase 1 fine-tune from `yw2a5dyl:v0` (H336 EP13). After 18 closed axes — and with the cumulative LOSS axis FULLY closed (7 nulls: H338 SP, H339 WSS, H341 wz-only, H346 focal EMA, H361 dir/mag, H364 hotspot, H368 grad-consistency) — every per-point reweighting and per-edge structural addition has broken the H342-tuned multi-channel balance via Lion gradient-mass shift on the untouched channel (most recently H368: +100bp VP regression on EP14 with WSS_grad mechanism CONVERGING — proof the mechanism worked but the basin couldn't absorb it).

**Pivot tier: non-capacity-additive architectural rewrites.** Replace existing computation with a different operator at the same (or fewer) parameter count. ISAB is a Lee et al. 2019 Set Transformer block that swaps O(S²) self-attention for O(SM) inducing-point cross-attention: compress `S=96` slice tokens → `M=32` learned inducing points via MAB(I, slice_tokens), then expand back via MAB(slice_tokens, H). The bottleneck through M=32 (3:1 compression) acts as an explicit information bottleneck on slice-token interactions.

Three reasons this is the right next attack:
1. **Replaces, doesn't add.** REPLACE layers idx 1, 2, 3 of the 5-layer Transolver stack (keep idx 0 and idx 4 unchanged). Net param overhead ≤ +0.3% (M=32 inducing points × 4 heads × dim_head=128 = 16K params per replaced layer). Lion basin shift risk is from gradient-mass redistribution, not from new params — REPLACING the operator forces a clean reroute through the new computational path from step 1.
2. **Different inductive bias from prior closures.** All 4 of edward's prior loss-tier attempts (H338/H361/H364/H368) modified what the model optimizes against. ISAB modifies HOW the slice tokens communicate — orthogonal axis.
3. **Set-Transformer compression on a set-token problem.** The slice-token bank is a learned set (no spatial order), so MAB compression is the operator that matches the structure.

**Why this beats encoder-axis (H351/H357/H358/H367 all closed):** those rearranged INPUT features. ISAB rearranges the INTERNAL mixing operator on the existing slice-token set — a different axis from rotated/anisotropic/curvature inputs.

**Reference:** Lee et al. 2019 "Set Transformer: A Framework for Attention-based Permutation-Invariant Neural Networks" ICML, Algorithm 2 (ISAB).

## Instructions

### 1. Architecture change in `target/models/transolver_layers.py` (or equivalent slice-attention module)

The current `create_slices` returns `slice_tokens` of shape `[B, H=4, S=96, dim_head=128]` (heads already split). Implement **per-head ISAB** (each head has its own set of M inducing points of dim `dim_head`).

Inducing-point parameter:
```python
# shape: [num_heads, M, dim_head]  — NOT [M, hidden_dim]
self.inducing_points = nn.Parameter(
    torch.empty(num_heads, M, dim_head)
)
nn.init.trunc_normal_(self.inducing_points, std=0.02)
```

ISAB forward (per-head):
```python
# slice_tokens: [B, H, S, dim_head]
# inducing: [H, M, dim_head] → expand to [B, H, M, dim_head]

# MAB step 1: H = MAB(I, slice_tokens) — inducing points attend to slice tokens
I_expanded = self.inducing_points.unsqueeze(0).expand(B, -1, -1, -1)  # [B, H, M, dim_head]
H_attn = scaled_dot_product_attention(
    query=I_expanded,            # [B, H, M, dim_head]
    key=slice_tokens,            # [B, H, S, dim_head]
    value=slice_tokens,          # [B, H, S, dim_head]
)  # → [B, H, M, dim_head]
H = LayerNorm(H_attn + I_expanded)
H = LayerNorm(H + FFN(H))

# MAB step 2: out = MAB(slice_tokens, H) — slice tokens attend to compressed reps
out_attn = scaled_dot_product_attention(
    query=slice_tokens,          # [B, H, S, dim_head]
    key=H,                       # [B, H, M, dim_head]
    value=H,                     # [B, H, M, dim_head]
)  # → [B, H, S, dim_head]
out = LayerNorm(out_attn + slice_tokens)
out = LayerNorm(out + FFN(out))
return out
```

Add a flag `--use_isab_layers "1,2,3"` (comma-separated layer indices to replace). For H370 Phase 1, default to `"1,2,3"` (REPLACE middle 3 of 5-layer stack; keep idx 0 and idx 4 as standard slice-attention). Add `--isab_inducing_points 32` (default M=32).

### 2. DDP correctness checks

- Set `find_unused_parameters=False` in DDP init (default; verify it's not flipped on by config). All inducing-point params MUST receive gradient every step or DDP will hang.
- Add a one-time assert in the first forward: `assert self.inducing_points.requires_grad and self.inducing_points.grad is None or self.inducing_points.grad.abs().sum() > 0` after first backward.
- Verify per-head shape is correct by printing `self.inducing_points.shape` once on rank 0 — should be `[4, 32, 128]` (or whatever your H/dim_head are).

### 3. Phase 1 recipe (3-epoch cosine-tail from `yw2a5dyl:v0` EP13)

```bash
cd target/
torchrun --standalone --nproc_per_node=8 train.py \
  --resume_from_checkpoint outputs/drivaerml/run-yw2a5dyl/checkpoint_ep13.pt \
  --use_isab_layers "1,2,3" \
  --isab_inducing_points 32 \
  --optimizer lion \
  --lr 9e-5 --lr_min 1e-6 --schedule cosine \
  --epochs_total 16 --max_epochs 16 \
  --batch_size 1 --grad_accum_steps 1 \
  --tau_z 1.67 \
  --data_root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --wandb_project senpai-v1-drivaerml-ddp8 \
  --wandb_group h370-isab-phase1 \
  --wandb_name edward/h370-isab-m32-phase1
```

Three epochs cosine tail (EP14, EP15, EP16) targeting a basin shift through the new ISAB operator. Lion is preserved because the H342 basin was found by Lion — switching optimizer here would confound the architectural test.

### 4. Pre-committed close rule (STRICT)

- If **EP14 val_abupt > 6.05%**, close immediately. Do NOT run EP15/EP16. Post the EP14 metrics, val_cal if you have TTA capacity for a quick screen, and the close-rule trigger in your SENPAI-RESULT comment.
- If EP14 val_abupt ≤ 6.05%, continue to EP15 and EP16, then run the standard H336/H342 TTA evaluation chain (K=5 + Student-t ν=4 + 8-res + mirror, calibrated) on the best EP.

### 5. SENPAI-RESULT marker

When complete (terminal or close-rule), post a comment with:
```
SENPAI-RESULT: {"terminal":true,"status":"<complete|closed>","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"val_abupt_calibrated","value":<number>},"test_metric":{"name":"test_abupt_calibrated","value":<number>}}
```

## Baseline

**Current SOTA (H342 PR #1526):**
- val_abupt_calibrated = **5.8962%**
- test_abupt_calibrated = **5.7357%**
- test_VP = 3.3751% | test_SP = 3.6124% | test_WSS = 6.6351% | test_WSS_z = 8.6122%
- Source: 3-checkpoint output-space avg (ep13+ep14+ep15) of `yw2a5dyl`/`0gjfv45i` with H336 K=5+Student-t ν=4 × 8-res × mirror TTA + per-channel affine calibration
- W&B: `3icmxaqe`, `qgw0ix77`, `ijadzof0`

**Merge gate (AND-logic, strict):**
- val_abupt_calibrated < **5.8962%** AND test_abupt_calibrated < **5.7357%**

**Reproduce baseline checkpoint:** `yw2a5dyl:v0` (H336 EP13, Lion, the canonical fine-tune root for all Phase 1 attacks).

**Pre-committed close rule for H370:** EP14 val_primary > 6.05% → close (45bp degradation budget; matches the H368 close threshold).

## Closed axes context (for the student)

After 18 closed axes, the live attack tier is **non-capacity-additive architectural rewrites**. The 4 most recent edward nulls (H338, H361, H364, H368) all share one pathology: they ADDED a per-point or per-edge term, which shifted Lion gradient mass and broke the untouched-channel balance the H342 basin was tuned to. ISAB does NOT add a term to the loss and does NOT add per-point computation — it REPLACES the slice-token mixing operator. This is intentional: the only remaining promising axis is changing HOW the existing computation flows, not WHAT it optimizes.
