### PR TITLE
H195: tau_y_loss_weight=1.3 on H183 stack (cross-flow axis)

### DIFF
--- a/train.py
+++ b/train.py
@@ -140,6 +140,7 @@ class Config:
     vol_p_charbonnier_weight: float = 0.0
     vol_p_charbonnier_eps: float = 1e-3
     tau_z_loss_weight: float = 1.0
+    tau_y_loss_weight: float = 1.0
     surface_out_width_factor: float = 1.0
 
 
@@ -357,6 +358,7 @@ def train_loss(
     vol_p_charbonnier_weight: float = 0.0,
     vol_p_charbonnier_eps: float = 1e-3,
     tau_z_loss_weight: float = 1.0,
+    tau_y_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float], torch.Tensor | None]:
     surface_curvature = getattr(batch, "surface_curvature", None)
     batch = batch.to(device)
@@ -416,8 +418,10 @@ def train_loss(
             # L0 absorbs the scaling so the lever acts through gradient
             # magnitudes (c_tau_z / G_bar) and the total backward signal,
             # without disturbing cp/tau_x/tau_y budgets.
+            # H195: same mechanism extended to tau_y (index 2) via
+            # tau_y_loss_weight, mirroring H36's per-axis injection.
             tau_z_scale = surface_per_ch.new_tensor(
-                [1.0, 1.0, 1.0, tau_z_loss_weight]
+                [1.0, 1.0, tau_y_loss_weight, tau_z_loss_weight]
             )
             surface_per_ch = surface_per_ch * tau_z_scale
             if loss_vol_p_charb is not None:
@@ -752,6 +756,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     vol_p_charbonnier_weight=config.vol_p_charbonnier_weight,
                     vol_p_charbonnier_eps=config.vol_p_charbonnier_eps,
                     tau_z_loss_weight=config.tau_z_loss_weight,
+                    tau_y_loss_weight=config.tau_y_loss_weight,
                 )
                 if (
                     config.use_y_symmetry_aug
@@ -802,6 +807,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/surface_loss_weighted": batch_loss_metrics["surface_loss_weighted"],
                             "train/volume_loss_weighted": batch_loss_metrics["volume_loss_weighted"],
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
+                            "train/tau_y_loss_weight": config.tau_y_loss_weight,
                         }
                     )
                     if "loss_wss_charb_unweighted" in batch_loss_metrics:


### PR DESCRIPTION
## Hypothesis

H192 (tau_z=1.5, currently running) is exploring the hardest wall-shear axis (z, 8.44%). This experiment isolates τ_y (the cross-flow/side-wash axis, H183 wss_y=6.98%) at a mild weight=1.3. 

The current H183 stack treats cp, τ_x, τ_y, τ_z identically in the surface loss (after per-channel head split). τ_y represents shear in the spanwise direction — it captures side-wash and separation patterns on the vehicle sides, which are structurally different from streamwise τ_x and wall-normal-adjacent τ_z. A mild gradient boost to τ_y should:

1. Prioritize τ_y channel gradient during training → push wss_y below 6.98% toward wss_x-tier (~5.70%)  
2. Improve ABUPT (mean of τ_x + τ_y + τ_z / 3) since τ_y is the mid-range axis
3. Not perturb the wall-normal penalty (H193) or LR (H194) axes — orthogonal to both running experiments

This is a clean, minimal-diff axis-weighting experiment matching the "mild tau_y/tau_z weights" directive from the human researcher team.

## Instructions

**Step 1: Add `tau_y_loss_weight` flag to `target/train.py`**

The existing `tau_z_loss_weight` mechanism (H36) already handles asymmetric axis boosting. Mirror it for τ_y:

In `class Config(dataclass)` (around line 142):
```python
tau_z_loss_weight: float = 1.0
tau_y_loss_weight: float = 1.0   # ADD THIS LINE
```

In `parse_args()`, in the generated argparse section for config fields — this is auto-generated from the dataclass so you may not need to do anything, just verify the flag appears in `--help` output.

In `compute_loss()` signature (around line 359):
```python
tau_z_loss_weight: float = 1.0,
tau_y_loss_weight: float = 1.0,   # ADD THIS LINE
```

In the tau_z_scale tensor (around line 419-422), change:
```python
# BEFORE:
tau_z_scale = surface_per_ch.new_tensor(
    [1.0, 1.0, 1.0, tau_z_loss_weight]
)
# AFTER:
tau_z_scale = surface_per_ch.new_tensor(
    [1.0, 1.0, tau_y_loss_weight, tau_z_loss_weight]
)
```

At the `compute_loss` call site (around line 754), add the new argument:
```python
tau_z_loss_weight=config.tau_z_loss_weight,
tau_y_loss_weight=config.tau_y_loss_weight,   # ADD THIS LINE
```

In the W&B logging block (around line 804), add:
```python
"train/tau_z_loss_weight": config.tau_z_loss_weight,
"train/tau_y_loss_weight": config.tau_y_loss_weight,   # ADD THIS LINE
```

**Step 2: DDP8 smoke test (1 EP) — REQUIRED before long run**

```bash
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 1e-4 --weight-decay 0.005 --lion-beta1 0.95 --lion-beta2 0.98 \
  --batch-size 1 --lr-warmup-epochs 1 --lr-cosine-t-max 1 --epochs 1 \
  --model-pe string_multisigma --pe-init-sigmas 0.25,0.5,1.0,2.0,4.0 --pe-num-features 16 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vol-p-charbonnier-weight 0.1 --wss-charbonnier-weight 0.1 --wss-charbonnier-axes z \
  --use-gradnorm --gradnorm-alpha 0.5 --gradnorm-min-w-vol-p 0.15 \
  --use-curvature-attention-bias --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --surface-out-width-factor 2.0 --per-channel-surface-heads \
  --train-surface-points 65000 --train-volume-points 65000 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999 --ema-start-step 500 \
  --tau-y-loss-weight 1.3 \
  --wandb-group h195-tau-y-loss-weight-1p3
```

Report EP1 val_WSS from the smoke. Expected: ~12.5-13.5% (same as H183 EP1 ~12.47%). If significantly above 15% or diverged, report back before launching main.

**Step 3: DDP8 main run (25 EP, ~21h)**

After smoke passes, launch:

```bash
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --optimizer lion --lr 1e-4 --weight-decay 0.005 --lion-beta1 0.95 --lion-beta2 0.98 \
  --batch-size 1 --lr-warmup-epochs 1 --lr-cosine-t-max 25 --epochs 25 \
  --model-pe string_multisigma --pe-init-sigmas 0.25,0.5,1.0,2.0,4.0 --pe-num-features 16 \
  --model-layers 6 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --vol-p-charbonnier-weight 0.1 --wss-charbonnier-weight 0.1 --wss-charbonnier-axes z \
  --use-gradnorm --gradnorm-alpha 0.5 --gradnorm-min-w-vol-p 0.15 \
  --use-curvature-attention-bias --use-y-symmetry-aug --y-symmetry-aug-prob 0.5 \
  --surface-out-width-factor 2.0 --per-channel-surface-heads \
  --train-surface-points 65000 --train-volume-points 65000 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --ema-decay 0.999 --ema-start-step 500 \
  --tau-y-loss-weight 1.3 \
  --wandb-group h195-tau-y-loss-weight-1p3
```

## Kill ladder (main run)

| EP | Gate | Metric |
|---:|---:|:---|
| EP3 | ≤7.10% | val_WSS — must match H183 EP3 shape ≈6.96% (±0.15pp) |
| EP5 | ≤6.90% | val_WSS |
| EP10 | ≤6.75% | val_WSS |
| EP15 | ≤6.60% | val_WSS |
| EP20 | ≤6.52% | val_WSS |
| EP25 | terminal | harvest test metrics |

Also monitor **val_primary/abupt_axis_mean_rel_l2_pct** (ABUPT) — if τ_y upweighting is working, ABUPT should be tracking at or below H183's EP10=6.52% by EP10.

If val_WSS misses any gate by >0.15pp, comment on the PR and stop. Do not continue past a gate miss.

## Baseline — H183 SOTA (PR #1510, run `guw83mge`)

| Metric | H183 SOTA | Floor |
|---|---:|---:|
| test_WSS | **6.4427%** ⭐ | — |
| test_VP | 3.4415% | ≤ 3.643% |
| test_SP | 3.5187% | ≤ 3.577% |
| test_ABUPT | 5.6152% | ≤ 5.844% |
| val_WSS EP10 | ~6.64% | — |
| Per-axis (H183): τ_x=5.698%, τ_y=6.981%, τ_z=8.436% | | |

All 4 floors must be cleared. H195 is a MERGE if test_WSS < 6.4427% AND all 4 floors are clear.

## Terminal results format

Once the main run completes (or is killed), post:
```
SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run_id>"],"primary_metric":{"name":"val_WSS","value":<EP25_val_WSS>},"test_metric":{"name":"test_WSS","value":<test_WSS>}}
```
