### PR TITLE
H373 — Transolver++ Local Adaptive Slice Pooling (k=16 kNN, temp=0.1)

### DIFF
--- a/eval_tta_h252.py
+++ b/eval_tta_h252.py
@@ -140,6 +140,11 @@ class EvalConfig:
     use_qk_norm: bool = True
     use_surf_to_vol_xattn: bool = True
     drop_path_max: float = 0.1
+    # H373: must match training-time slice-pool config so the loaded
+    # checkpoint reproduces the routing topology used at training time.
+    slice_pool_mode: str = "global"
+    slice_pool_neighbors: int = 16
+    slice_pool_temperature: float = 0.1
 
     amp_mode: str = "bf16"
     debug: bool = False  # 2 val + 2 test cases
@@ -195,6 +200,9 @@ def build_model(cfg: EvalConfig) -> SurfaceTransolver:
         use_qk_norm=cfg.use_qk_norm,
         use_surf_to_vol_xattn=cfg.use_surf_to_vol_xattn,
         drop_path_max=cfg.drop_path_max,
+        slice_pool_mode=cfg.slice_pool_mode,
+        slice_pool_neighbors=cfg.slice_pool_neighbors,
+        slice_pool_temperature=cfg.slice_pool_temperature,
     )
 
 

--- a/model.py
+++ b/model.py
@@ -260,18 +260,43 @@ class TransolverAttention(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         use_qk_norm: bool = False,
+        slice_pool_mode: str = "global",
+        slice_pool_neighbors: int = 16,
+        slice_pool_temperature: float = 0.1,
     ):
         super().__init__()
         if hidden_dim % num_heads != 0:
             raise ValueError("hidden_dim must be divisible by num_heads")
+        if slice_pool_mode not in ("global", "local_adaptive"):
+            raise ValueError(
+                f"slice_pool_mode must be 'global' or 'local_adaptive', got {slice_pool_mode!r}"
+            )
+        if slice_pool_mode == "local_adaptive":
+            if slice_pool_neighbors <= 0:
+                raise ValueError("slice_pool_neighbors must be > 0 in local_adaptive mode")
+            if slice_pool_temperature <= 0.0:
+                raise ValueError(
+                    "slice_pool_temperature must be > 0 in local_adaptive mode"
+                )
         self.hidden_dim = hidden_dim
         self.num_heads = num_heads
         self.dim_head = hidden_dim // num_heads
         self.num_slices = num_slices
         self.dropout = dropout
         self.use_qk_norm = use_qk_norm
+        self.slice_pool_mode = slice_pool_mode
+        # Cap k at num_slices so top-k can never exceed S.
+        self.slice_pool_neighbors = min(int(slice_pool_neighbors), int(num_slices))
+        self.slice_pool_temperature = float(slice_pool_temperature)
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
+        if slice_pool_mode == "local_adaptive":
+            # H373: local_adaptive bypasses the learned per-head temperature
+            # in favour of a fixed slice_pool_temperature override, so freeze
+            # the parameter to (a) keep EP13-EMA load behaviour intact via
+            # strict=False, (b) skip DDP gradient sync for an unused param,
+            # and (c) skip EMA bookkeeping (EMA filters on requires_grad).
+            self.temperature.requires_grad = False
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
         self.in_project_fx = LinearProjection(hidden_dim, hidden_dim)
         self.in_project_slice = LinearProjection(self.dim_head, num_slices)
@@ -289,8 +314,32 @@ class TransolverAttention(nn.Module):
         batch_size, num_tokens, _ = x.shape
         fx_mid = self.in_project_fx(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         x_mid = self.in_project_x(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
-        slice_logits = self.in_project_slice(x_mid) / self.temperature
+        slice_logits_raw = self.in_project_slice(x_mid)
+        if self.slice_pool_mode == "local_adaptive":
+            # H373: top-k feature-space local adaptive pool. For each
+            # (batch, head, point) row of slice_logits_raw, keep only the k
+            # largest entries (= "k nearest slices in feature space" since
+            # in_project_slice acts as an inner-product with learned slice
+            # query vectors). Mask the rest to -inf before softmax with a
+            # fixed local temperature (0.1 by default). Zero new parameters
+            # — the learned per-head ``self.temperature`` is bypassed in
+            # local_adaptive mode and the EP13 EMA warm-start preserves
+            # ``in_project_slice`` exactly.
+            k = self.slice_pool_neighbors
+            _, topk_idx = slice_logits_raw.topk(k, dim=-1)
+            keep_mask = torch.zeros_like(slice_logits_raw, dtype=torch.bool)
+            keep_mask.scatter_(-1, topk_idx, True)
+            # Clamp before scaling to prevent fp16/bf16 overflow at τ=0.1 (×10).
+            # ±50 raw → ±500 scaled, well within fp32 and bf16 max (~3.4e38/~6.5e4).
+            slice_logits = slice_logits_raw.clamp(-50.0, 50.0) / self.slice_pool_temperature
+            slice_logits = slice_logits.masked_fill(~keep_mask, float("-inf"))
+        else:
+            slice_logits = slice_logits_raw / self.temperature
         slice_weights = F.softmax(slice_logits, dim=-1)
+        # Belt-and-suspenders guard: if an entire row is -inf (e.g. all-masked
+        # degenerate edge case), softmax returns NaN; replace with 0 rather
+        # than propagating NaN through the loss to a silent rank crash.
+        slice_weights = torch.nan_to_num(slice_weights, nan=0.0, posinf=0.0, neginf=0.0)
         if attn_mask is not None:
             slice_weights = slice_weights * attn_mask[:, None, :, None].to(
                 device=slice_weights.device,
@@ -330,6 +379,9 @@ class TransformerBlock(nn.Module):
         dropout: float = 0.0,
         use_qk_norm: bool = False,
         drop_path_prob: float = 0.0,
+        slice_pool_mode: str = "global",
+        slice_pool_neighbors: int = 16,
+        slice_pool_temperature: float = 0.1,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -340,6 +392,9 @@ class TransformerBlock(nn.Module):
             num_slices=num_slices,
             dropout=dropout,
             use_qk_norm=use_qk_norm,
+            slice_pool_mode=slice_pool_mode,
+            slice_pool_neighbors=slice_pool_neighbors,
+            slice_pool_temperature=slice_pool_temperature,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
@@ -366,6 +421,9 @@ class Transformer(nn.Module):
         dropout: float = 0.0,
         use_qk_norm: bool = False,
         drop_path_max: float = 0.0,
+        slice_pool_mode: str = "global",
+        slice_pool_neighbors: int = 16,
+        slice_pool_temperature: float = 0.1,
     ):
         super().__init__()
         if depth > 1:
@@ -383,6 +441,9 @@ class Transformer(nn.Module):
                     dropout=dropout,
                     use_qk_norm=use_qk_norm,
                     drop_path_prob=drop_path_probs[i],
+                    slice_pool_mode=slice_pool_mode,
+                    slice_pool_neighbors=slice_pool_neighbors,
+                    slice_pool_temperature=slice_pool_temperature,
                 )
                 for i in range(depth)
             ]
@@ -419,6 +480,9 @@ class SurfaceTransolver(nn.Module):
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
         drop_path_max: float = 0.0,
+        slice_pool_mode: str = "global",
+        slice_pool_neighbors: int = 16,
+        slice_pool_temperature: float = 0.1,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -502,6 +566,9 @@ class SurfaceTransolver(nn.Module):
         )
         self.surface_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
         self.volume_placeholder = nn.Parameter(torch.rand(1, 1, n_hidden) / n_hidden)
+        self.slice_pool_mode = slice_pool_mode
+        self.slice_pool_neighbors = slice_pool_neighbors
+        self.slice_pool_temperature = slice_pool_temperature
         self.backbone = Transformer(
             depth=n_layers,
             hidden_dim=n_hidden,
@@ -511,6 +578,9 @@ class SurfaceTransolver(nn.Module):
             dropout=dropout,
             use_qk_norm=use_qk_norm,
             drop_path_max=drop_path_max,
+            slice_pool_mode=slice_pool_mode,
+            slice_pool_neighbors=slice_pool_neighbors,
+            slice_pool_temperature=slice_pool_temperature,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         if use_aux_decoder_heads:

--- a/train.py
+++ b/train.py
@@ -97,6 +97,9 @@ class Config:
     model_mlp_ratio: int = 4
     model_slices: int = 96
     model_dropout: float = 0.0
+    slice_pool_mode: str = "global"
+    slice_pool_neighbors: int = 16
+    slice_pool_temperature: float = 0.1
     rff_num_features: int = 0
     rff_sigma: float = 1.0
     rff_init_sigmas: str = ""
@@ -272,6 +275,27 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "the best-only checkpoint after every validation event. Used "
             "to keep EP14/15/16 EMA checkpoints for downstream TTA eval."
         ),
+        "slice_pool_mode": (
+            "H373: Transolver slice-pool routing. 'global' (default) is the "
+            "standard Transolver dense softmax over all K slices using the "
+            "learned per-head temperature. 'local_adaptive' restricts the "
+            "softmax to each point's top-k slices in feature space (Wu et "
+            "al., Transolver++, ICML 2025, arxiv:2502.02414): mask all but "
+            "the top-k entries of slice_logits to -inf, apply softmax with "
+            "--slice-pool-temperature. Zero new parameters, preserves the "
+            "N->K->N token bijection."
+        ),
+        "slice_pool_neighbors": (
+            "H373: k for local_adaptive slice pool. Each point's slice "
+            "softmax is restricted to its top-k highest logits across the K "
+            "slices. Capped at K. Ignored when --slice-pool-mode=global."
+        ),
+        "slice_pool_temperature": (
+            "H373: softmax temperature in local_adaptive mode. Overrides the "
+            "learned per-head ``self.temperature`` only inside the masked "
+            "softmax (global mode is unchanged). Lower => sharper "
+            "assignment; default 0.1. Ignored when --slice-pool-mode=global."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -429,6 +453,9 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
         drop_path_max=config.drop_path_max,
+        slice_pool_mode=config.slice_pool_mode,
+        slice_pool_neighbors=config.slice_pool_neighbors,
+        slice_pool_temperature=config.slice_pool_temperature,
     )
 
 


### PR DESCRIPTION
## Hypothesis

**Replace global slice softmax pooling in Transolver with local-neighborhood-constrained pooling (k=16 nearest neighbors, temperature=0.1).**

The current Transolver slice pool assigns each surface point to one of K=32 slices via a GLOBAL softmax — meaning a single slice may average over physically disconnected regions (hood + underbody, A-pillar + diffuser). For τ_z, the relevant physics is **highly local** (separation lines, A-pillar vortex attachment, wake shoulder), and distant surface regions have different τ_z signatures. Global pooling forces the model to average over physically incoherent neighborhoods — degrading the fine-grained boundary-layer structure where τ_z errors are largest.

**Local adaptive pooling** restricts each slice to a k-NN neighborhood: surface point i can contribute only to slices whose centroid is among its k=16 nearest neighbors (Euclidean on x,y,z). The softmax temperature is τ=0.1 to sharpen the assignment. Zero new parameters — the projection matrices are unchanged, only the pooling INDEX changes.

**Why this is fundamentally different from prior nulls:**
- Loss reweighting axis (7 nulls H338-H368): scalar reweighting can't move WSS_z. **This changes the model's forward-pass attention TOPOLOGY, not the loss signal.**
- Input-feature axis (4 nulls H348/H359/H360/H369): zero-pad warm-start of new geometric features failed to propagate signal through cosine-tail. **This adds NO new input features — it changes how existing features are aggregated.**
- Encoder/normal axis (4 nulls H351/H357/H358/H367): tangent-basis output heads, GeoTransolver content embedding — all closed. **This is upstream of those: the slice-pooling step that FEEDS the encoder.**
- ISAB operator family (closed at single-layer bound H370/H371): inducing-point compression breaks token-count bijection. **This preserves token bijection 100% — slice → point is unchanged, only the slice-pool routing changes.**

**Empirical grounding:** Transolver++ (Wu et al., ICML 2025, arxiv:2502.02414) shows local adaptive pooling delivers **+8-12% relative L2 on NS-2D and Elasticity** — closest-domain results to surface CFD. GAOT (ETH 2025, arxiv:2505.18781) confirms geometry-aware multiscale local pooling beats global pooling on PDE operator transformers.

## Instructions

**Branch:** `frieren/h373-transolver-pp-local-slice-pool` (created)

**Step 1 — Find and modify `target/model/transolver.py` `SlicePool.forward()` (or equivalent slice-pooling class):**

Add CLI flags:
```
--slice-pool-mode local_adaptive   # NEW: switches from global softmax → local kNN softmax
--slice-pool-neighbors 16          # k for kNN
--slice-pool-temperature 0.1       # softmax temperature inside local pool
```

Implementation approach:
- Current forward (assumed): `slice_assignment = softmax(point_features @ slice_centroid^T / temp)` — shape (N_points, K_slices), global softmax over K slices.
- New forward (local_adaptive): for each point i, compute the top-k=16 nearest slice CENTROIDS by Euclidean distance on (x,y,z); mask out all other slices to −inf before softmax. Apply softmax with temp=0.1 over only the top-k entries. Output remains shape (N_points, K_slices) but sparse with at most 16 non-zero entries per row.
- The slice-centroid positions: if learnable parameters, use the current learned values from EP13 EMA warm-start. If derived from feature space, use the current projection.
- **CRITICAL — token bijection preservation:** N_points input → K_slices intermediate → N_points output is preserved. No information compression bottleneck. The change is in the SLICE → POINT routing only.

**Step 2 — Smoke check (2-epoch debug, no warm-start, batch_size=4):**
```bash
torchrun --standalone --nproc-per-node=8 train.py \
  --epochs 2 --debug \
  --slice-pool-mode local_adaptive --slice-pool-neighbors 16 --slice-pool-temperature 0.1 \
  --wandb-group h373-frieren-smoke \
  --wandb-name "frieren/h373-smoke-local-slice"
```
Verify: no NaN in slice_assignment matrix, training loss decreases vs random init.

**Step 3 — Phase 1 (EP13 → EP14-EP16, 8 GPUs DDP, 3-epoch cosine tail):**

If smoke clean, launch primary:
```bash
H185_EP13_EMA="outputs/ensemble_cache/run-yw2a5dyl-epoch-13-ema/checkpoint.pt"

torchrun --standalone --nproc-per-node=8 train.py \
  --warm-start-from "$H185_EP13_EMA" \
  --epochs 3 --start-epoch 13 \
  --optimizer lion --lr 9e-5 --lr-cosine-t-max 3 --lr-min 1e-6 \
  --weight-decay 5e-4 --batch-size 4 \
  --tau-y-loss-weight 1.3 --tau-z-loss-weight 1.67 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --grad-clip-norm 0.5 --ema-decay 0.999 \
  --use-qk-norm --rff-num-features 16 --pos-encoding-mode string_separable \
  --model-layers 5 --hidden-dim 512 --heads 4 --slices 128 \
  --slice-pool-mode local_adaptive --slice-pool-neighbors 16 --slice-pool-temperature 0.1 \
  --vol-points-schedule "0:65536" \
  --wandb-group h373-frieren-transolver-pp \
  --wandb-name "frieren/h373-phase1-local-slice"
```

**Pre-committed kill rules:**
- EP14 val_primary > 6.05% → CLOSE (mechanism not propagating through EP13 basin)
- EP14 val_WSS_z > H336 EP13 baseline (~9.06%) → CLOSE (local pooling disrupted boundary-layer rep)
- EP14 val_primary ≤ 6.05% AND val_WSS_z drops ≥30bp → continue EP15-EP16, run TTA cascade

**Step 4 — TTA cascade (if Phase 1 passes EP14 gate):**

Apply H336 recipe to best-val checkpoint:
```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint <best_ckpt.pt> \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 5 --antithetic-noise \
  --weight-noise-dist student_t --weight-noise-df 4 \
  --test-time-calibration \
  --wandb-group h373-frieren-tta \
  --wandb-name "frieren/h373-tta-cal"
```
Then test split with same recipe.

## Baseline

**Current SOTA H342 (PR #1526, MERGED):**
- val_abupt_calibrated = **5.8962%**
- test_abupt_calibrated = **5.7357%**
- test_VP = 3.3751%, test_SP = 3.6124%, test_WSS = 6.6351%, **test_WSS_z = 8.6122%**

**Merge gate (strict AND):** val_cal < 5.8962% AND test_cal < 5.7357%

**Estimated wall-clock:** ~3.5h/epoch × 4 epochs = ~14h on 8 GPUs (Phase 1 requires attention kernel rewrite, may take longer). TTA cascade ~7h. Total ≤ 21h.

**Implementation references:**
- Transolver++ (Wu et al., ICML 2025) arxiv:2502.02414 — primary reference; their open-source code at github.com/thuml/Transolver++ has `LocalAdaptiveSlicePool` class
- Transolver (Wu et al., ICML 2024) arxiv:2402.02366 — our baseline architecture
- PointConv (Wu et al., CVPR 2019) — local kNN pooling on point clouds as precedent

**Constraints:**
- DDP×8 mandatory
- τ_z normalization LOCKED at 1.67 (never modify)
- Read-only: `data/loader.py`, `data/preload.py`, `data/split_manifest.json`
- Zero new parameters (only INDEX change inside SlicePool)
- Preserve token-count bijection (N → K → N, NEVER compress)

Use `--wandb_group h373-frieren-transolver-pp`. Submit terminal `SENPAI-RESULT` marker on completion.
