### PR TITLE
H374 — Self-Consistency vs Frozen EP13 EMA Teacher on τ_z Channel (λ=0.1)

### DIFF
--- a/tools/h374_smoke_test.py
+++ b/tools/h374_smoke_test.py
@@ -1,0 +1,230 @@
+"""H374 smoke test: verify teacher-loading and consistency-loss compute path.
+
+Confirms:
+- Teacher (EP13 EMA) loads with zero missing/unexpected keys against the
+  H336/H342 model recipe.
+- Teacher is in eval(), requires_grad=False on all params.
+- A single forward+backward with --self-consistency-weight 0.1 produces a
+  finite consistency loss and nonzero student gradient.
+- consistency_loss is identically zero when student == teacher (sanity).
+- consistency_loss is nonzero after a perturbation of the student weights.
+"""
+
+from __future__ import annotations
+
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from train import (  # noqa: E402
+    Config,
+    SURFACE_CHANNEL_INDEX,
+    build_model,
+    parse_self_consistency_channels,
+    train_loss,
+)
+from trainer_runtime import TargetTransform  # noqa: E402
+
+
+def make_config() -> Config:
+    cfg = Config(
+        model_layers=5,
+        model_hidden_dim=512,
+        model_heads=4,
+        model_mlp_ratio=4,
+        model_slices=128,
+        use_qk_norm=True,
+        use_surf_to_vol_xattn=True,
+        rff_num_features=16,
+        rff_init_sigmas="0.25,0.5,1.0,2.0,4.0",
+        pos_encoding_mode="string_separable",
+        drop_path_max=0.1,
+        teacher_ckpt="outputs/drivaerml/resume_cache/yw2a5dyl/epoch-13/checkpoint.pt",
+        self_consistency_weight=0.1,
+        self_consistency_channels="wss_z",
+        self_consistency_loss="mse",
+        tau_y_loss_weight=1.3,
+        tau_z_loss_weight=1.67,
+        surface_loss_weight=2.0,
+        volume_loss_weight=0.5,
+    )
+    return cfg
+
+
+def make_fake_batch(device, B=2, N_surface=512, N_volume=256):
+    from data.loader import SurfaceBatch
+
+    surface_x = torch.randn(B, N_surface, 7, device=device)
+    surface_y = torch.randn(B, N_surface, 4, device=device)
+    surface_mask = torch.ones(B, N_surface, device=device, dtype=torch.bool)
+    volume_x = torch.randn(B, N_volume, 4, device=device)
+    volume_y = torch.randn(B, N_volume, 1, device=device)
+    volume_mask = torch.ones(B, N_volume, device=device, dtype=torch.bool)
+    return SurfaceBatch(
+        case_ids=[f"case_{i}" for i in range(B)],
+        surface_x=surface_x,
+        surface_y=surface_y,
+        surface_mask=surface_mask,
+        volume_x=volume_x,
+        volume_y=volume_y,
+        volume_mask=volume_mask,
+        metadata=[{} for _ in range(B)],
+    )
+
+
+def main() -> int:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    cfg = make_config()
+
+    print(f"Device: {device}")
+
+    teacher_path = Path(cfg.teacher_ckpt)
+    assert teacher_path.is_file(), f"teacher ckpt not found: {teacher_path}"
+    print(f"Teacher checkpoint: {teacher_path}")
+
+    # Build student and teacher with the same recipe; load teacher weights.
+    torch.manual_seed(0)
+    student = build_model(cfg).to(device)
+    teacher = build_model(cfg).to(device)
+    ck = torch.load(str(teacher_path), map_location="cpu", weights_only=False)
+    sd = ck["model"]
+    sd = {k.removeprefix("module."): v for k, v in sd.items()}
+    missing, unexpected = teacher.load_state_dict(sd, strict=False)
+    print(f"Teacher load: missing={len(missing)} unexpected={len(unexpected)}")
+    assert len(missing) == 0, f"unexpected missing keys: {missing[:10]}"
+    assert len(unexpected) == 0, f"unexpected extra keys: {unexpected[:10]}"
+
+    # Also load student from same checkpoint so consistency_loss starts at 0.
+    student.load_state_dict(sd, strict=False)
+    teacher.eval()
+    for p in teacher.parameters():
+        p.requires_grad_(False)
+
+    n_grad = sum(int(p.requires_grad) for p in teacher.parameters())
+    assert n_grad == 0, f"teacher has {n_grad} trainable params"
+
+    indices = parse_self_consistency_channels(cfg.self_consistency_channels)
+    assert indices == [SURFACE_CHANNEL_INDEX["wss_z"]], f"got {indices}"
+    print(f"Consistency channel indices: {indices}")
+
+    batch = make_fake_batch(device)
+    transform = TargetTransform(
+        surface_y_mean=torch.zeros(4, device=device),
+        surface_y_std=torch.ones(4, device=device),
+        volume_y_mean=torch.zeros(1, device=device),
+        volume_y_std=torch.ones(1, device=device),
+    )
+    surface_weights = torch.tensor(
+        [1.0, 1.0, cfg.tau_y_loss_weight, cfg.tau_z_loss_weight], device=device
+    )
+
+    # Case 1a: student.eval() == teacher.eval() → no drop_path/dropout noise,
+    # consistency loss should be effectively 0 modulo bf16 rounding.
+    student.eval()
+    loss_eq, metrics_eq = train_loss(
+        student,
+        batch,
+        transform,
+        device,
+        amp_mode="bf16",
+        surface_loss_weight=cfg.surface_loss_weight,
+        volume_loss_weight=cfg.volume_loss_weight,
+        surface_channel_weights=surface_weights,
+        teacher_model=teacher,
+        self_consistency_weight=cfg.self_consistency_weight,
+        self_consistency_channel_indices=indices,
+        self_consistency_loss_type=cfg.self_consistency_loss,
+    )
+    print(f"Case 1a (student.eval()==teacher) metrics: {metrics_eq}")
+    cl_eq = metrics_eq.get("consistency_loss", float("nan"))
+    assert cl_eq is not None and cl_eq < 1e-5, (
+        f"Expected consistency_loss ~0 when student.eval()==teacher, got {cl_eq}"
+    )
+    assert torch.isfinite(loss_eq), f"loss non-finite: {loss_eq}"
+
+    # Case 1b: student.train() (drop_path active) vs teacher.eval() — should be
+    # small but nonzero due to drop_path noise (this is the real training case).
+    student.train()
+    _, metrics_train = train_loss(
+        student,
+        batch,
+        transform,
+        device,
+        amp_mode="bf16",
+        surface_loss_weight=cfg.surface_loss_weight,
+        volume_loss_weight=cfg.volume_loss_weight,
+        surface_channel_weights=surface_weights,
+        teacher_model=teacher,
+        self_consistency_weight=cfg.self_consistency_weight,
+        self_consistency_channel_indices=indices,
+        self_consistency_loss_type=cfg.self_consistency_loss,
+    )
+    cl_train = metrics_train["consistency_loss"]
+    print(f"Case 1b (student.train()==teacher, drop_path noise) cl={cl_train:.6f}")
+    assert 0.0 <= cl_train < 1.0, f"unexpected drop_path-induced cl: {cl_train}"
+
+    # Case 2: perturb student → consistency_loss must be > 0.
+    with torch.no_grad():
+        for p in student.parameters():
+            p.add_(torch.randn_like(p) * 1e-2)
+    student.zero_grad()
+    loss_diff, metrics_diff = train_loss(
+        student,
+        batch,
+        transform,
+        device,
+        amp_mode="bf16",
+        surface_loss_weight=cfg.surface_loss_weight,
+        volume_loss_weight=cfg.volume_loss_weight,
+        surface_channel_weights=surface_weights,
+        teacher_model=teacher,
+        self_consistency_weight=cfg.self_consistency_weight,
+        self_consistency_channel_indices=indices,
+        self_consistency_loss_type=cfg.self_consistency_loss,
+    )
+    print(f"Case 2 (perturbed student) metrics: {metrics_diff}")
+    cl_diff = metrics_diff["consistency_loss"]
+    cl_w = metrics_diff["consistency_loss_weighted"]
+    assert cl_diff > 1e-4, f"Expected consistency_loss >0 after perturbation, got {cl_diff}"
+    assert abs(cl_w - cl_diff * cfg.self_consistency_weight) < 1e-9
+    assert torch.isfinite(loss_diff)
+
+    # Backward — student must receive nonzero gradient through the consistency
+    # path.  Verify gradient flows through the surface output head AND the
+    # shared backbone (encoder), not just the head.
+    loss_diff.backward()
+    backbone_grad_norm = 0.0
+    surface_out_grad_norm = 0.0
+    volume_out_grad_norm = 0.0
+    for n, p in student.named_parameters():
+        if p.grad is None:
+            continue
+        gn = float(p.grad.detach().norm().item())
+        if n.startswith("surface_out") or n.startswith("surface_bias"):
+            surface_out_grad_norm += gn
+        elif n.startswith("volume_out") or n.startswith("volume_bias"):
+            volume_out_grad_norm += gn
+        elif n.startswith("backbone"):
+            backbone_grad_norm += gn
+    print(f"Backbone gradient norm sum: {backbone_grad_norm:.4f}")
+    print(f"Surface-out gradient norm sum: {surface_out_grad_norm:.4f}")
+    print(f"Volume-out gradient norm sum: {volume_out_grad_norm:.4f}")
+    assert backbone_grad_norm > 0.0, "no gradient flowed into backbone"
+    assert surface_out_grad_norm > 0.0, "no gradient flowed into surface head"
+    assert volume_out_grad_norm > 0.0, "volume head should still receive base-loss gradient"
+
+    # Case 3: teacher param.grad must remain None.
+    teacher_has_grad = any(p.grad is not None for p in teacher.parameters())
+    assert not teacher_has_grad, "teacher params received grad!"
+
+    print("\nH374 smoke test PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/train.py
+++ b/train.py
@@ -54,6 +54,7 @@ from trainer_runtime import (
     is_valid_primary_metric,
     loader_kwargs,
     make_loaders,
+    masked_mean,
     masked_mse,
     metric_namespace,
     weighted_channel_mse,
@@ -146,6 +147,11 @@ class Config:
     epochs_already_done: int = 0
     save_every_epoch: bool = False
     debug: bool = False
+    # H374: self-consistency vs frozen EMA teacher on noisy channel(s)
+    teacher_ckpt: str = ""
+    self_consistency_weight: float = 0.0
+    self_consistency_channels: str = "wss_z"
+    self_consistency_loss: str = "mse"
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -271,6 +277,29 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "H244: save EMA checkpoint as 'checkpoint_ep{N}.pt' alongside "
             "the best-only checkpoint after every validation event. Used "
             "to keep EP14/15/16 EMA checkpoints for downstream TTA eval."
+        ),
+        "teacher_ckpt": (
+            "H374: path to a frozen teacher checkpoint (e.g. EP13 EMA) used "
+            "for self-consistency regularization. The teacher is loaded with "
+            "the SAME --model-* / --rff-* / --use-qk-norm / --use-surf-to-vol-xattn "
+            "/ --pos-encoding-mode flags as the student, set to eval() and "
+            "requires_grad=False, and never updated. Empty disables the "
+            "self-consistency loss."
+        ),
+        "self_consistency_weight": (
+            "H374: scalar lambda multiplying the self-consistency MSE/L1 loss "
+            "between student and teacher predictions on selected channel(s). "
+            "0.0 disables (default). Recommended start 0.1 for tau_z."
+        ),
+        "self_consistency_channels": (
+            "H374: comma-separated list of surface channels to apply the "
+            "self-consistency loss to. Valid tokens: sp, wss_x, wss_y, wss_z. "
+            "Default 'wss_z' (tau_z only — the noisiest channel)."
+        ),
+        "self_consistency_loss": (
+            "H374: which pointwise distance to use for the self-consistency "
+            "loss. 'mse' (L2, advisor default) or 'l1' (more robust to "
+            "noisy teacher predictions). Default 'mse'."
         ),
     }
     for field in fields(Config):
@@ -432,6 +461,39 @@ def build_model(config: Config) -> SurfaceTransolver:
     )
 
 
+SURFACE_CHANNEL_INDEX = {"sp": 0, "wss_x": 1, "wss_y": 2, "wss_z": 3}
+
+
+def parse_self_consistency_channels(spec: str) -> list[int]:
+    tokens = [t.strip().lower() for t in (spec or "").split(",") if t.strip()]
+    if not tokens:
+        return []
+    indices: list[int] = []
+    for token in tokens:
+        if token not in SURFACE_CHANNEL_INDEX:
+            raise ValueError(
+                f"--self-consistency-channels token {token!r} unknown; "
+                f"valid: {sorted(SURFACE_CHANNEL_INDEX)}"
+            )
+        indices.append(SURFACE_CHANNEL_INDEX[token])
+    return sorted(set(indices))
+
+
+def _self_consistency_distance(
+    student_pred: torch.Tensor,
+    teacher_pred: torch.Tensor,
+    mask: torch.Tensor,
+    loss_type: str,
+) -> torch.Tensor:
+    loss_type = loss_type.lower()
+    diff = student_pred - teacher_pred
+    if loss_type == "mse":
+        return masked_mean(diff.square(), mask)
+    if loss_type == "l1":
+        return masked_mean(diff.abs(), mask)
+    raise ValueError(f"--self-consistency-loss {loss_type!r} not in {{mse, l1}}")
+
+
 def train_loss(
     model: nn.Module,
     batch,
@@ -442,10 +504,19 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
+    teacher_model: nn.Module | None = None,
+    self_consistency_weight: float = 0.0,
+    self_consistency_channel_indices: list[int] | None = None,
+    self_consistency_loss_type: str = "mse",
 ) -> tuple[torch.Tensor, dict[str, float]]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
+    use_consistency = (
+        teacher_model is not None
+        and self_consistency_weight > 0.0
+        and self_consistency_channel_indices
+    )
     with autocast_context(device, amp_mode):
         out = model(
             surface_x=batch.surface_x,
@@ -467,13 +538,42 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+
+        consistency_loss: torch.Tensor | None = None
+        if use_consistency:
+            with torch.no_grad():
+                teacher_out = teacher_model(
+                    surface_x=batch.surface_x,
+                    surface_mask=batch.surface_mask,
+                    volume_x=batch.volume_x,
+                    volume_mask=batch.volume_mask,
+                )
+                teacher_surface = teacher_out["surface_preds"].detach()
+            consistency_terms = []
+            for idx in self_consistency_channel_indices:
+                consistency_terms.append(
+                    _self_consistency_distance(
+                        out["surface_preds"][..., idx : idx + 1],
+                        teacher_surface[..., idx : idx + 1],
+                        batch.surface_mask,
+                        self_consistency_loss_type,
+                    )
+                )
+            consistency_loss = torch.stack(consistency_terms).mean()
+            loss = loss + self_consistency_weight * consistency_loss
+
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    if consistency_loss is not None:
+        consistency_value = float(consistency_loss.detach().cpu().item())
+        metrics["consistency_loss"] = consistency_value
+        metrics["consistency_loss_weighted"] = self_consistency_weight * consistency_value
+    return loss, metrics
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -927,6 +1027,60 @@ def main(argv: Iterable[str] | None = None) -> None:
         use_channel_weights = bool(
             (config.tau_y_loss_weight != 1.0) or (config.tau_z_loss_weight != 1.0)
         )
+
+        # H374: self-consistency teacher (frozen EP13 EMA). Built BEFORE the
+        # student is wrapped in torch.compile/DDP so we can reuse build_model().
+        teacher_model: nn.Module | None = None
+        self_consistency_channel_indices: list[int] = []
+        if config.teacher_ckpt:
+            if config.self_consistency_weight <= 0.0:
+                raise ValueError(
+                    "--teacher-ckpt set but --self-consistency-weight is 0; "
+                    "either drop the teacher path or pass a positive weight."
+                )
+            if config.use_gradnorm:
+                raise ValueError(
+                    "--teacher-ckpt is not currently wired into the GradNorm "
+                    "training path; run without --use-gradnorm or extend "
+                    "per_task_train_losses()."
+                )
+            self_consistency_channel_indices = parse_self_consistency_channels(
+                config.self_consistency_channels
+            )
+            if not self_consistency_channel_indices:
+                raise ValueError(
+                    "--self-consistency-channels must list at least one channel "
+                    "from {sp, wss_x, wss_y, wss_z}."
+                )
+            teacher_path = Path(config.teacher_ckpt)
+            if not teacher_path.is_file():
+                raise FileNotFoundError(f"--teacher-ckpt not found: {teacher_path}")
+            teacher_model = build_model(config).to(device)
+            teacher_ck = torch.load(str(teacher_path), map_location="cpu", weights_only=False)
+            teacher_state_dict = teacher_ck["model"] if "model" in teacher_ck else teacher_ck
+            teacher_state_dict = {
+                k.removeprefix("module."): v for k, v in teacher_state_dict.items()
+            }
+            t_missing, t_unexpected = teacher_model.load_state_dict(
+                teacher_state_dict, strict=False
+            )
+            teacher_model.eval()
+            for param in teacher_model.parameters():
+                param.requires_grad_(False)
+            channel_token_lookup = {v: k for k, v in SURFACE_CHANNEL_INDEX.items()}
+            channel_names = [
+                channel_token_lookup[idx] for idx in self_consistency_channel_indices
+            ]
+            if state.is_main:
+                print(
+                    f"H374 self-consistency teacher loaded from {teacher_path} "
+                    f"(epoch={teacher_ck.get('epoch')}, "
+                    f"source={teacher_ck.get('checkpoint_source')}, "
+                    f"missing={len(t_missing)}, unexpected={len(t_unexpected)}); "
+                    f"lambda={config.self_consistency_weight}, "
+                    f"channels={channel_names}, loss={config.self_consistency_loss}"
+                )
+
         if config.compile_model:
             model = torch.compile(model)
         if state.enabled:
@@ -1081,6 +1235,14 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["mirror_augmentation"] = config.mirror_augmentation
             wandb.summary["epochs_already_done"] = config.epochs_already_done
             wandb.summary["save_every_epoch"] = config.save_every_epoch
+            if teacher_model is not None:
+                wandb.summary["self_consistency/enabled"] = True
+                wandb.summary["self_consistency/weight"] = config.self_consistency_weight
+                wandb.summary["self_consistency/channels"] = config.self_consistency_channels
+                wandb.summary["self_consistency/loss"] = config.self_consistency_loss
+                wandb.summary["self_consistency/teacher_ckpt"] = config.teacher_ckpt
+            else:
+                wandb.summary["self_consistency/enabled"] = False
 
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
@@ -1230,6 +1392,10 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        teacher_model=teacher_model,
+                        self_consistency_weight=config.self_consistency_weight,
+                        self_consistency_channel_indices=self_consistency_channel_indices,
+                        self_consistency_loss_type=config.self_consistency_loss,
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
@@ -1270,6 +1436,13 @@ def main(argv: Iterable[str] | None = None) -> None:
                             "train/tau_z_loss_weight": config.tau_z_loss_weight,
                         }
                     )
+                    if "consistency_loss" in batch_loss_metrics:
+                        train_log["train/consistency_loss"] = batch_loss_metrics[
+                            "consistency_loss"
+                        ]
+                        train_log["train/consistency_loss_weighted"] = batch_loss_metrics[
+                            "consistency_loss_weighted"
+                        ]
                 if gradnorm_metrics:
                     train_log.update(gradnorm_metrics)
 


### PR DESCRIPTION
## Hypothesis

**Add τ_z-only self-consistency regularization vs frozen EP13 EMA teacher during EP14-EP16 cosine tail. Anchors fine-tuning trajectory to the EP13 manifold on the noisiest channel.**

Mechanism: Freeze the EP13 EMA checkpoint as a teacher. During fine-tuning, add a consistency loss:
```
L_consistency = λ × MSE(student_τ_z, teacher_τ_z.detach())
```
applied **only on the τ_z channel**, with λ=0.1. Teacher gradients are detached; teacher is frozen (no grad updates). This is **zero added parameters** — the consistency loss is computed against the cached EP13 teacher prediction.

**Why this attacks WSS_z specifically:**
- test_WSS_z = 8.61% — 2.4× larger than WSS_x (5.35%) and 2.4× larger than the AB-UPT target (3.63%). All other channels (WSS_x, WSS_y, p_s, p_v) are at or below target.
- The CFD labels for τ_z are the **noisiest** (most sensitive to mesh resolution and solver convergence). Empirically, the 21-axis closure log shows the EP13 → EP15 fine-tune trajectory drifts on τ_z in ways the loss signal cannot correct.
- The EP13 EMA has already learned a reasonable τ_z manifold (the basis of all SOTA recipes since H244). Fine-tuning EP14-EP16 without an anchor allows over-fitting to noisy τ_z samples while WSS_x/y are well-behaved.
- Consistency anchors the τ_z manifold drift WITHOUT preventing improvement on other channels. The teacher provides a "soft prior" only where the student is uncertain.

**Distinct from prior nulls:**
- Loss reweighting (7 nulls): scalar reweighting of τ_z gradient magnitude — closed. **This is a NEW LOSS TERM, not a reweighting of existing loss.**
- TTA / cal (15+ nulls): inference-time only. **This changes the TRAINING manifold.**
- Encoder / decoder / input-feature axes (13 nulls combined): structural changes to forward pass. **This is purely a training-time regularizer — zero structural change.**
- Mean Teacher (Tarvainen & Valpola, NeurIPS 2017) and NoRD (Wang et al., NeurIPS 2024) — consistency vs frozen EMA reduces error on noisy-label regimes (CFD τ_z is the analog).

**Edward — your 5/5 close-rule streak (H338/H361/H364/H368/H370/H371) has bounded the loss-reweighting, encoder, and operator-replacement tiers cleanly. This hypothesis exits those tiers entirely: it's a training-time regularizer with zero structural change. Different axis, fresh look.**

## Instructions

**Branch:** `edward/h374-self-consistency-ep13-teacher-tauz` (will create)

**Step 1 — Add CLI flags to `target/train.py`:**
```
--teacher-ckpt "/path/to/ep13_ema.pt"   # frozen EP13 EMA as teacher
--self-consistency-weight 0.1            # λ for consistency loss (start 0.1)
--self-consistency-channels wss_z        # apply ONLY to τ_z channel
--self-consistency-loss mse              # L2 consistency
```

Implementation:
- Load teacher checkpoint at init, set `requires_grad=False`, set `.eval()` mode.
- In training step: after the student forward pass and student loss computation:
  - Run teacher forward pass on the SAME input batch (gradient detached, no_grad context).
  - Extract teacher's τ_z predictions (channel 4 of surface_y, after model output — match the same normalization the student uses).
  - Compute `L_consistency = λ × MSE(student_τ_z_pred, teacher_τ_z_pred.detach())`.
  - Total loss: `L_total = L_student + L_consistency`.
- Teacher EVAL mode is fixed across training; do not update teacher.
- Important: extract ONLY the τ_z slice from the prediction tensor (channel index where τ_z lives in surface_y). DO NOT apply consistency to τ_x, τ_y, p_s, or volume.

**Step 2 — Smoke check (1-epoch debug, batch_size=4, no warm-start):**
```bash
torchrun --standalone --nproc-per-node=8 train.py \
  --epochs 1 --debug \
  --teacher-ckpt "outputs/ensemble_cache/run-yw2a5dyl-epoch-13-ema/checkpoint.pt" \
  --self-consistency-weight 0.1 --self-consistency-channels wss_z --self-consistency-loss mse \
  --wandb-group h374-edward-smoke \
  --wandb-name "edward/h374-smoke-consistency"
```
Verify: loss decomposition logged (student_loss, consistency_loss separate scalars), no NaN, training loss decreasing.

**Step 3 — Phase 1 (EP13 → EP14-EP16 from EP13 EMA, 8 GPUs DDP, 3-epoch cosine tail):**
```bash
H185_EP13_EMA="outputs/ensemble_cache/run-yw2a5dyl-epoch-13-ema/checkpoint.pt"

torchrun --standalone --nproc-per-node=8 train.py \
  --warm-start-from "$H185_EP13_EMA" \
  --teacher-ckpt "$H185_EP13_EMA" \
  --self-consistency-weight 0.1 --self-consistency-channels wss_z --self-consistency-loss mse \
  --epochs 3 --start-epoch 13 \
  --optimizer lion --lr 9e-5 --lr-cosine-t-max 3 --lr-min 1e-6 \
  --weight-decay 5e-4 --batch-size 4 \
  --tau-y-loss-weight 1.3 --tau-z-loss-weight 1.67 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --grad-clip-norm 0.5 --ema-decay 0.999 \
  --use-qk-norm --rff-num-features 16 --pos-encoding-mode string_separable \
  --model-layers 5 --hidden-dim 512 --heads 4 --slices 128 \
  --vol-points-schedule "0:65536" \
  --wandb-group h374-edward-self-consistency \
  --wandb-name "edward/h374-phase1-lambda0p1"
```

**Pre-committed kill rules:**
- EP14 val_primary > 6.00% → CLOSE immediately
- EP14 val_WSS_z > H336 EP13 baseline (~9.06%) → CLOSE (consistency over-anchors)
- EP14 val_primary ≤ 6.00% AND val_WSS_z drops ≥30bp → continue, run TTA cascade
- If Phase 1 lands marginal (val_primary 6.00-6.05%), launch a fast Phase 2 with λ=0.05 on a 1-epoch reseed — DO NOT escalate to λ=0.2+ (over-regularization risk)

**Step 4 — TTA cascade (if Phase 1 passes):**
Apply H336 K=5 + Student-t ν=4 + 8-res + mirror TTA + per-channel cal on best ckpt, then test split.

## Baseline

**Current SOTA H342 (PR #1526, MERGED):**
- val_abupt_calibrated = **5.8962%**
- test_abupt_calibrated = **5.7357%**
- test_VP = 3.3751%, test_SP = 3.6124%, test_WSS = 6.6351%, **test_WSS_z = 8.6122%**

**Merge gate (strict AND):** val_cal < 5.8962% AND test_cal < 5.7357%

**Per-channel error budget (τ_z is the bottleneck):**
| Channel | H342 test | AB-UPT target | Gap |
|---------|-----------|---------------|-----|
| **WSS_z** | **8.6122%** | 3.63% | **4.98pp** |
| WSS_x | 5.3512% | 5.35% | 0.00pp |
| WSS_y | 3.6488% | 3.65% | 0.00pp |
| p_s | 3.8201% | 3.82% | 0.00pp |
| p_v | 3.3735% | 3.42% | 0.00pp |

**Estimated wall-clock:** ~3.5h/epoch × 3 epochs = ~10.5h on 8 GPUs (Phase 1, slightly slower due to teacher forward pass). TTA cascade ~7h. Total ≤ 18h.

**References:**
1. NoRD (Wang et al., NeurIPS 2024) — "Noise-Resilient Self-Distillation"; consistency vs frozen EMA reduces error on noisy-label benchmarks.
2. Mean Teacher (Tarvainen & Valpola, NeurIPS 2017, arxiv:1703.01780) — foundational EMA-teacher consistency reference.
3. Kaltenbach & Koutsourelakis (2021) — "Knowledge Distillation for Physical Simulations" — distillation from fixed checkpoint improves OOD generalization on wall-bounded flows.

**Constraints:**
- DDP×8 mandatory
- τ_z normalization LOCKED at 1.67 (never modify)
- Read-only: `data/loader.py`, `data/preload.py`, `data/split_manifest.json`
- Zero parameters added (teacher frozen, only λ scalar)
- No ensembles

Use `--wandb_group h374-edward-self-consistency`. Submit terminal `SENPAI-RESULT` marker on completion.

**Kill v1 H371 ranks first if still running** (PR #1566 closed Finding V; the rank0/1/2/...rank7 runs in W&B `edward/h371-isab-m32-1layer-idx2-phase1-rank*` are wasted GPU). After cleaning up, launch H374 fresh.
