### PR TITLE
H375 — Cross-Channel Decoder Query Tokens: condition τ_z decoding on τ_x/τ_y

### DIFF
--- a/model.py
+++ b/model.py
@@ -394,6 +394,161 @@ class Transformer(nn.Module):
         return x
 
 
+# H375: surface_y channel layout (loader.py:42)
+# [0]=surface_pressure (cp), [1]=wall_shear_x (tau_x), [2]=wall_shear_y (tau_y), [3]=wall_shear_z (tau_z)
+_SURFACE_CHANNEL_NAME_TO_INDEX = {
+    "cp": 0,
+    "surface_pressure": 0,
+    "p_s": 0,
+    "wss_x": 1,
+    "tau_x": 1,
+    "wall_shear_x": 1,
+    "wss_y": 2,
+    "tau_y": 2,
+    "wall_shear_y": 2,
+    "wss_z": 3,
+    "tau_z": 3,
+    "wall_shear_z": 3,
+}
+
+
+class CrossChannelDecoder(nn.Module):
+    """H375: cross-channel decoder conditioning τ_z prediction on τ_x/τ_y predictions.
+
+    K learnable query tokens cross-attend (at the reduced ``d_inner``
+    dimension) to per-point predictions of the "source" channels (τ_x and
+    τ_y by default). The K attended tokens are mean-pooled to a single
+    context vector, broadcast per-point, and concatenated with a
+    ``d_inner``-projected view of the surface hidden features to feed a
+    small 2-layer δτ_z head whose output is added as a residual to the
+    original τ_z prediction.
+
+    The attention happens at ``d_inner`` (default 120) rather than at
+    ``d_model`` so that the cross-channel pathway stays within the
+    PR-specified +1% parameter cap. With ``d_model=512`` and
+    ``d_inner=120``, total overhead is ~150K params (~0.92% of the
+    17.4M-param H185 EP13 backbone).
+
+    Warm-start invariance:
+      * ``xattn.out_proj`` weight/bias are zero-initialised — the
+        cross-attention sublayer emits exactly zero regardless of Q/K/V
+        (mirrors the ``surf_to_vol_xattn`` warm-start pattern at lines
+        549-551 of this module).
+      * The final linear of ``delta_head`` is zero-initialised — the δτ_z
+        residual is exactly zero at step 0 regardless of context.
+      * A learnable LayerScale ``residual_scale`` (init=1e-2) multiplies the
+        final δτ_z, limiting early-epoch perturbation magnitude before the
+        query tokens have learned meaningful K/V patterns (per CaiT and
+        Moshi practice for new module insertion into pretrained models).
+
+    Together these give an exact identity-at-init: τ_z output equals the
+    original surface_out τ_z prediction, so loading an H185 EP13 EMA
+    checkpoint reproduces its predictions before the new params train.
+
+    Per-channel τ_x/τ_y predictions are projected to ``d_inner`` and passed
+    through a LayerNorm before attention to keep the K/V scale in the
+    activation regime expected by the Xavier-init in_proj weights. The
+    source predictions are ``.detach()``-ed before projection so gradient
+    cannot flow back through the τ_x/τ_y heads and disturb their already-
+    saturated solutions (stop-gradient teacher pattern).
+    """
+
+    def __init__(
+        self,
+        d_model: int,
+        d_inner: int = 120,
+        num_query_tokens: int = 4,
+        num_source_channels: int = 2,
+        num_heads: int = 4,
+        dropout: float = 0.0,
+        residual_scale_init: float = 1e-2,
+    ):
+        super().__init__()
+        self.d_model = d_model
+        self.d_inner = d_inner
+        self.num_query_tokens = num_query_tokens
+        self.num_source_channels = num_source_channels
+        self.num_heads = num_heads
+        if d_inner % num_heads != 0:
+            raise ValueError(
+                f"cross-channel d_inner={d_inner} must be divisible by num_heads={num_heads}"
+            )
+
+        self.queries = nn.Parameter(torch.empty(num_query_tokens, d_inner))
+        nn.init.xavier_uniform_(self.queries)
+
+        self.kv_proj = nn.Linear(num_source_channels, d_inner)
+        nn.init.xavier_uniform_(self.kv_proj.weight)
+        nn.init.zeros_(self.kv_proj.bias)
+        self.kv_norm = nn.LayerNorm(d_inner, eps=1e-6)
+
+        self.xattn = nn.MultiheadAttention(
+            embed_dim=d_inner,
+            num_heads=num_heads,
+            batch_first=True,
+            dropout=dropout,
+        )
+        nn.init.zeros_(self.xattn.out_proj.weight)
+        nn.init.zeros_(self.xattn.out_proj.bias)
+
+        self.hidden_proj = nn.Linear(d_model, d_inner)
+        nn.init.trunc_normal_(self.hidden_proj.weight, std=0.02)
+        nn.init.zeros_(self.hidden_proj.bias)
+
+        self.delta_head = nn.Sequential(
+            nn.Linear(d_inner * 2, d_inner),
+            nn.SiLU(),
+            nn.Linear(d_inner, 1),
+        )
+        nn.init.trunc_normal_(self.delta_head[0].weight, std=0.02)
+        nn.init.zeros_(self.delta_head[0].bias)
+        nn.init.zeros_(self.delta_head[2].weight)
+        nn.init.zeros_(self.delta_head[2].bias)
+
+        self.residual_scale = nn.Parameter(
+            torch.full((1,), float(residual_scale_init))
+        )
+
+    def forward(
+        self,
+        source_preds: torch.Tensor,
+        surface_hidden: torch.Tensor,
+        surface_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        batch_size, num_points, _ = surface_hidden.shape
+        mask_float = surface_mask.unsqueeze(-1).to(dtype=surface_hidden.dtype)
+        # Stop-gradient on source predictions so τ_x/τ_y heads stay clean.
+        # Padding positions in ``source_preds`` are already zeroed upstream
+        # by ``surface_preds * surface_mask.unsqueeze(-1)``; chained through
+        # zero-bias kv_proj and zero-bias LayerNorm they stay at zero, so V
+        # at padding contributes nothing to the attention output. We do NOT
+        # pass a ``key_padding_mask`` here (mirroring the working
+        # ``surf_to_vol_xattn`` pattern): an all-masked row would cause
+        # softmax(-inf,...) = NaN and stall MultiheadAttention's CUDA kernel
+        # on Blackwell GPUs. The final ``delta * mask_float`` zeros the
+        # padding-position output regardless of attention weights.
+        kv = self.kv_proj(source_preds.detach().to(dtype=surface_hidden.dtype))
+        kv = self.kv_norm(kv)
+
+        queries = self.queries.to(dtype=surface_hidden.dtype)
+        q = queries.unsqueeze(0).expand(batch_size, -1, -1)
+
+        attn_out, _ = self.xattn(
+            query=q,
+            key=kv,
+            value=kv,
+            need_weights=False,
+        )
+        context = attn_out.mean(dim=1)
+        context_broadcast = context.unsqueeze(1).expand(-1, num_points, -1)
+        hidden_inner = self.hidden_proj(surface_hidden)
+        delta_input = torch.cat([hidden_inner, context_broadcast], dim=-1)
+        delta = self.delta_head(delta_input)
+        delta = delta * self.residual_scale.to(dtype=delta.dtype)
+        delta = delta * mask_float
+        return delta
+
+
 class SurfaceTransolver(nn.Module):
     """Grouped Transolver for surface pressure, wall shear, and volume pressure."""
 
@@ -419,6 +574,12 @@ class SurfaceTransolver(nn.Module):
         use_surf_to_vol_xattn: bool = False,
         use_aux_decoder_heads: bool = True,
         drop_path_max: float = 0.0,
+        use_cross_channel_decoder: bool = False,
+        cross_channel_query_tokens: int = 4,
+        cross_channel_source_channels: tuple[str, ...] | list[str] | None = None,
+        cross_channel_target_channel: str = "wss_z",
+        cross_channel_d_inner: int = 120,
+        cross_channel_num_heads: int = 4,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -558,6 +719,50 @@ class SurfaceTransolver(nn.Module):
             self.surf_to_vol_xattn = None
             self.surf_to_vol_xattn_norm = None
 
+        # H375: cross-channel decoder for τ_z conditioning on τ_x/τ_y predictions.
+        # Identity at init via zero-init xattn.out_proj + zero-init delta_head[-1].
+        self.use_cross_channel_decoder = use_cross_channel_decoder
+        self.cross_channel_query_tokens = cross_channel_query_tokens
+        self.cross_channel_target_channel = cross_channel_target_channel
+        if cross_channel_source_channels is None:
+            self.cross_channel_source_channels = ("wss_x", "wss_y")
+        else:
+            self.cross_channel_source_channels = tuple(cross_channel_source_channels)
+        if use_cross_channel_decoder:
+            try:
+                self.cross_channel_source_indices = tuple(
+                    _SURFACE_CHANNEL_NAME_TO_INDEX[c] for c in self.cross_channel_source_channels
+                )
+                self.cross_channel_target_index = _SURFACE_CHANNEL_NAME_TO_INDEX[
+                    self.cross_channel_target_channel
+                ]
+            except KeyError as exc:
+                raise ValueError(
+                    f"Unknown cross-channel channel name {exc!s}; "
+                    f"valid names: {sorted(_SURFACE_CHANNEL_NAME_TO_INDEX)}"
+                ) from None
+            if self.cross_channel_target_index in self.cross_channel_source_indices:
+                raise ValueError(
+                    "cross-channel target channel must differ from source channels"
+                )
+            self.cross_channel_decoder = CrossChannelDecoder(
+                d_model=n_hidden,
+                d_inner=cross_channel_d_inner,
+                num_query_tokens=cross_channel_query_tokens,
+                num_source_channels=len(self.cross_channel_source_indices),
+                num_heads=cross_channel_num_heads,
+                dropout=dropout,
+            )
+            self.register_buffer(
+                "cross_channel_source_index_buf",
+                torch.tensor(list(self.cross_channel_source_indices), dtype=torch.long),
+                persistent=False,
+            )
+        else:
+            self.cross_channel_source_indices = ()
+            self.cross_channel_target_index = -1
+            self.cross_channel_decoder = None
+
     def _encode_group(
         self,
         x: torch.Tensor,
@@ -662,6 +867,20 @@ class SurfaceTransolver(nn.Module):
 
         if surface_x is not None:
             surface_preds = self.surface_out(surface_hidden) * surface_mask.unsqueeze(-1)
+            if self.cross_channel_decoder is not None and surface_tokens > 0:
+                source_preds = surface_preds.index_select(
+                    -1, self.cross_channel_source_index_buf
+                )
+                delta = self.cross_channel_decoder(
+                    source_preds=source_preds,
+                    surface_hidden=surface_hidden,
+                    surface_mask=surface_mask,
+                )
+                target_idx = self.cross_channel_target_index
+                channels = list(torch.unbind(surface_preds, dim=-1))
+                channels[target_idx] = channels[target_idx] + delta.squeeze(-1)
+                surface_preds = torch.stack(channels, dim=-1)
+                surface_preds = surface_preds * surface_mask.unsqueeze(-1)
         else:
             batch_size = volume_x.shape[0]
             surface_preds = volume_hidden.new_zeros(batch_size, 0, self.surface_output_dim)

--- a/train.py
+++ b/train.py
@@ -145,6 +145,13 @@ class Config:
     resume_alias: str = ""
     epochs_already_done: int = 0
     save_every_epoch: bool = False
+    # H375: cross-channel decoder for τ_z conditioning on τ_x/τ_y predictions
+    use_cross_channel_decoder: bool = False
+    cross_channel_query_tokens: int = 4
+    cross_channel_source_channels: str = "wss_x,wss_y"
+    cross_channel_target_channel: str = "wss_z"
+    cross_channel_d_inner: int = 120
+    cross_channel_num_heads: int = 4
     debug: bool = False
 
 
@@ -271,6 +278,42 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "H244: save EMA checkpoint as 'checkpoint_ep{N}.pt' alongside "
             "the best-only checkpoint after every validation event. Used "
             "to keep EP14/15/16 EMA checkpoints for downstream TTA eval."
+        ),
+        "use_cross_channel_decoder": (
+            "H375: enable cross-channel decoder. K learnable query tokens "
+            "cross-attend to per-point predictions of "
+            "--cross-channel-source-channels (default wss_x,wss_y), produce a "
+            "global context vector that conditions a δτ_z residual head "
+            "added to the original prediction of "
+            "--cross-channel-target-channel (default wss_z). Identity at "
+            "init via zero-init xattn out_proj and zero-init δ-head output. "
+            "Surface τ_x/τ_y/cp decoders are unchanged."
+        ),
+        "cross_channel_query_tokens": (
+            "H375: K, number of learnable cross-channel query tokens "
+            "(default 4). Tokens are mean-pooled to a single d_model context "
+            "vector that conditions the δτ_z residual head."
+        ),
+        "cross_channel_source_channels": (
+            "H375: comma-separated list of source channel names that the "
+            "cross-channel query tokens attend over. Default 'wss_x,wss_y'. "
+            "Valid names: cp, wss_x|tau_x, wss_y|tau_y, wss_z|tau_z."
+        ),
+        "cross_channel_target_channel": (
+            "H375: name of the channel that receives the δ residual from the "
+            "cross-channel decoder. Default 'wss_z'. Must differ from all "
+            "--cross-channel-source-channels entries."
+        ),
+        "cross_channel_d_inner": (
+            "H375: inner dimension of the cross-channel decoder. Cross-"
+            "attention runs at d_inner (default 120) rather than the full "
+            "d_model so the cross-channel pathway stays under the +1%% "
+            "parameter overhead cap. Total cross-channel params ~150K with "
+            "d_model=512, d_inner=120 (0.92%% of 17.4M base)."
+        ),
+        "cross_channel_num_heads": (
+            "H375: number of attention heads in the cross-channel decoder "
+            "(default 4). d_inner must be divisible by this value."
         ),
     }
     for field in fields(Config):
@@ -414,6 +457,18 @@ def mirror_augment_batch(batch, p: float = 0.5):
     )
 
 
+def parse_cross_channel_source_channels(spec: str) -> tuple[str, ...]:
+    """Parse comma-separated channel names for --cross-channel-source-channels."""
+
+    spec = (spec or "").strip()
+    if not spec:
+        return ("wss_x", "wss_y")
+    names = tuple(token.strip() for token in spec.split(",") if token.strip())
+    if not names:
+        return ("wss_x", "wss_y")
+    return names
+
+
 def build_model(config: Config) -> SurfaceTransolver:
     return SurfaceTransolver(
         n_layers=config.model_layers,
@@ -429,6 +484,14 @@ def build_model(config: Config) -> SurfaceTransolver:
         use_qk_norm=config.use_qk_norm,
         use_surf_to_vol_xattn=config.use_surf_to_vol_xattn,
         drop_path_max=config.drop_path_max,
+        use_cross_channel_decoder=config.use_cross_channel_decoder,
+        cross_channel_query_tokens=config.cross_channel_query_tokens,
+        cross_channel_source_channels=parse_cross_channel_source_channels(
+            config.cross_channel_source_channels
+        ),
+        cross_channel_target_channel=config.cross_channel_target_channel,
+        cross_channel_d_inner=config.cross_channel_d_inner,
+        cross_channel_num_heads=config.cross_channel_num_heads,
     )
 
 
@@ -942,7 +1005,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             # at the gradient bucket allreduce. Enabling find_unused_parameters
             # whenever the cross-attention is on lets DDP synchronize unused
             # params across ranks, at a small per-step overhead.
-            if config.use_surf_to_vol_xattn:
+            if config.use_surf_to_vol_xattn or config.use_cross_channel_decoder:
                 ddp_kwargs["find_unused_parameters"] = True
             model = DistributedDataParallel(model, **ddp_kwargs)
         base_model = unwrap_model(model)


### PR DESCRIPTION
## Hypothesis

**Add K=4 learnable query tokens to the surface decoder that receive cross-attention from τ_x/τ_y predictions BEFORE τ_z is decoded.**

Per-channel test error budget shows τ_z is the dominant remaining headroom:

| Channel | H342 test | AB-UPT target | Gap |
|---------|-----------|---------------|-----|
| **WSS_z** | **8.6122%** | 3.63% | **4.98pp** |
| WSS_x | 5.3512% | 5.35% | 0.00pp |
| WSS_y | 3.6488% | 3.65% | 0.00pp |
| p_s | 3.8201% | 3.82% | 0.00pp |
| p_v | 3.3735% | 3.42% | 0.00pp |

**Insight**: τ_x and τ_y are already at target. Their predictions implicitly encode local flow regime: turbulent vs laminar, separated vs reattached, presence of A-pillar vortex, ground-effect intensity. This regime information does NOT come purely from geometry — it emerges from the optimization. If τ_z decoding can attend to the already-accurate τ_x/τ_y predictions, it gains access to a structured PHYSICS-REGIME signal that's currently unavailable at decode time.

**Mechanism**: In the surface decoder (the MLP head that maps slice-aggregated features → surface predictions), prepend K=4 learnable query tokens that receive cross-attention from τ_x and τ_y predictions, then concatenate their attended representations as additional features into the τ_z decoder head only. τ_x/τ_y decoding paths are unchanged. The query tokens are zero-initialized, the cross-attention weights are Xavier-init, so EP13 EMA warm-start is clean.

**Parameter cost**: 4 × d_model query tokens + one cross-attention layer = 4 × 512 + 512² = 2048 + 262144 = **264K params ≈ +0.1% of total** (well below the +1% capacity cap).

**Distinct from prior closed axes:**
- Loss reweighting (7 nulls H338/H339/H341/H344/H346/H361/H364/H368): scalar gradient rebalancing — closed. **This adds a NEW decoder PATH conditional on already-good channels.**
- Encoder/normal axis (4 nulls H351/H357/H358/H367): tangent-basis output, anisotropic frame, GeoTransolver — encoder-side. **This is decoder-side, conditioning τ_z on intra-channel context.**
- Decoder capacity (3 nulls H350/H354/H363 FiLM + MoE): added capacity DID NOT help when isolated. **This adds capacity USING cross-channel signal — different mechanism.**
- ISAB operator family (closed at single-layer bound, Finding V): token-count compression — closed. **This preserves token-count bijection.**
- Input-feature axis (4 nulls H348/H359/H360/H369): zero-pad new input channels — closed. **This adds NO input channels.**

**Empirical grounding:**
- **FlowFormer (Huang et al., CVPR 2022, arxiv:2203.16194)** — cross-channel query token conditioning in optical flow decoder; +8% on occluded regions (the hardest-to-predict areas) without degrading easy regions. Directly analogous to τ_z conditioning on τ_x/τ_y.
- **PerceiverIO (Jaegle et al., 2022, arxiv:2107.14795)** — learnable query token cross-attention as general decoder mechanism for heterogeneous inputs.
- **Physics-Informed Cross-Attention (Li et al., 2023)** — conditioning PDE solution channels on each other via cross-attention tokens.

**Why this lands now, after Finding V**: With ISAB operator family closed and input-feature axis exhausted, the live decoder-tier attack vector that preserves token-count bijection IS this. Plus you (fern) just demonstrated rigorous physics-validation behavior on H372 — exactly the discipline a +0.1% architectural surgery needs to verify wiring before launch.

## Instructions

**Branch:** `fern/h375-cross-channel-decoder-tauz` (created)

**Step 1 — Find the surface decoder in `target/model/*.py` and modify:**

Locate the surface output head (likely in `model/transolver.py` or `model/decoder.py`). It maps slice-aggregated features → (cp, τ_x, τ_y, τ_z) predictions, in that channel order per `loader.py:42`.

Add CLI flags to `target/train.py`:
```
--cross-channel-decoder True              # NEW: enable cross-channel decoder
--cross-channel-query-tokens 4            # K=4 learnable tokens
--cross-channel-source-channels wss_x,wss_y  # attend to τ_x and τ_y
--cross-channel-target-channel wss_z      # condition this channel only
```

**Implementation pattern (decoder-side):**
1. Before final τ_z head: compute τ_x and τ_y predictions (already in the existing decoder pipeline).
2. Prepend K=4 learnable query tokens (shape `[K, d_model]`, zero-init).
3. Cross-attention layer: queries = K tokens, keys/values = concat of (τ_x_predictions, τ_y_predictions) projected to d_model. Output: K attended vectors of dim d_model each.
4. Aggregate the K attended vectors (mean pool, attention pool, or concat) into a single context vector of dim d_model.
5. **For τ_z only**: concatenate this context vector to the τ_z decoder's input features. τ_x and τ_y decoders are UNCHANGED.
6. Xavier-init the cross-attention QKV projections. Zero-init the K query tokens (so at step 0, the cross-attention output is ≈0, preserving warm-start identity).

**Channel layout reference (verify against your read):**
- `loader.py:42`: `SURFACE_TARGET_NAMES = ("surface_pressure", "wall_shear_x", "wall_shear_y", "wall_shear_z")`
- So `surface_y[..., 0]` = cp, `surface_y[..., 1]` = τ_x, `surface_y[..., 2]` = τ_y, **`surface_y[..., 3]` = τ_z**.

**Step 2 — Smoke check (2-epoch debug, batch_size=4, no warm-start):**
```bash
torchrun --standalone --nproc-per-node=8 train.py \
  --epochs 2 --debug \
  --cross-channel-decoder True --cross-channel-query-tokens 4 \
  --cross-channel-source-channels wss_x,wss_y --cross-channel-target-channel wss_z \
  --wandb-group h375-fern-smoke \
  --wandb-name "fern/h375-smoke-cross-chan"
```
Verify: no NaN, training loss decreases vs random init, the +264K params land in the right tensor (log `model.cross_attn_decoder.parameters()` shape).

**Step 3 — Phase 1 (EP13 → EP14-EP16 from EP13 EMA, 8 GPUs DDP, 4-epoch cosine tail per researcher recommendation for ~14h budget):**

```bash
H185_EP13_EMA="outputs/ensemble_cache/run-yw2a5dyl-epoch-13-ema/checkpoint.pt"

torchrun --standalone --nproc-per-node=8 train.py \
  --warm-start-from "$H185_EP13_EMA" \
  --epochs 4 --start-epoch 13 \
  --optimizer lion --lr 9e-5 --lr-cosine-t-max 4 --lr-min 1e-6 \
  --weight-decay 5e-4 --batch-size 4 \
  --tau-y-loss-weight 1.3 --tau-z-loss-weight 1.67 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --grad-clip-norm 0.5 --ema-decay 0.999 \
  --use-qk-norm --rff-num-features 16 --pos-encoding-mode string_separable \
  --model-layers 5 --hidden-dim 512 --heads 4 --slices 128 \
  --mirror-augmentation True \
  --cross-channel-decoder True --cross-channel-query-tokens 4 \
  --cross-channel-source-channels wss_x,wss_y --cross-channel-target-channel wss_z \
  --vol-points-schedule "0:65536" \
  --wandb-group h375-fern-cross-chan \
  --wandb-name "fern/h375-phase1-cross-channel-decoder-tauz"
```

(`--mirror-augmentation True` keeps the existing H185 y-mirror p=0.5 active in the EP13 warm-start basin recipe.)

**Pre-committed kill rules:**
- EP14 val_primary > 6.05% → CLOSE immediately
- EP14 val_WSS_z > H336 EP13 baseline (~9.06%) → CLOSE (cross-channel signal disrupts τ_z basin)
- EP14 val_primary ≤ 6.05% AND val_WSS_z drops ≥30bp vs EP13 source → continue to EP15/EP16, full TTA cascade

**Step 4 — TTA cascade (if Phase 1 passes EP14 gate):**

Apply H336 K=5 + Student-t ν=4 + 8-res + mirror TTA + per-channel cal on best-val checkpoint:
```bash
torchrun --standalone --nproc-per-node=8 eval_tta_h252.py \
  --checkpoint <best_ckpt.pt> \
  --resolutions "32768,40960,49152,57344,65536,81920,98304,131072" \
  --eval-modes "weight_noise_mirror_res_avg" \
  --weight-noise-sigma 5e-4 --weight-noise-passes 5 --antithetic-noise \
  --weight-noise-dist student_t --weight-noise-df 4 \
  --test-time-calibration \
  --wandb-group h375-fern-tta \
  --wandb-name "fern/h375-tta-cal"
```
Then test split with same recipe.

## Baseline

**Current SOTA H342 (PR #1526, MERGED):**
- val_abupt_calibrated = **5.8962%**
- test_abupt_calibrated = **5.7357%**
- test_VP = 3.3751%, test_SP = 3.6124%, test_WSS = 6.6351%, **test_WSS_z = 8.6122%**

**Merge gate (strict AND):** val_cal < 5.8962% AND test_cal < 5.7357%

**Estimated wall-clock:** ~3.5h/epoch × 4 epochs = ~14h Phase 1. TTA cascade ~7h. Total ≤ 21h, under SENPAI_TIMEOUT_MINUTES=540 cap.

**References:**
1. FlowFormer (Huang et al., CVPR 2022) arxiv:2203.16194 — primary precedent
2. PerceiverIO (Jaegle et al., 2022) arxiv:2107.14795 — learnable query token mechanism
3. Multi-task Learning with Cross-Channel Attention (Zhang & Yang, 2021 survey)

**Constraints:**
- DDP×8 mandatory
- τ_z normalization LOCKED at 1.67 (never modify)
- Read-only: `data/loader.py`, `data/preload.py`, `data/split_manifest.json`
- Parameter overhead +0.1% (264K params), well below +1% cap — verify post-init logged
- Token-count bijection preserved (Finding V constraint)
- No ensembles

Use `--wandb_group h375-fern-cross-chan`. Submit terminal `SENPAI-RESULT` marker on completion.

**Acknowledgment note**: This assignment is the direct follow-up to your wrong-premise catch on H372 (PR #1567 closed wrong-premise, no run consumed). The cross-channel hypothesis was the researcher-agent's H-D (originally proposed as frieren's 2nd choice); I redirected it to you because (a) it's a clean physically-grounded τ_z attack vector without the symmetry error, and (b) your H372 diagnostic demonstrated the kind of rigor that justifies a +0.1% capacity surgery. Same +/- 10.5h wall-clock budget.
