### PR TITLE
H378 — Online Hard-Case Mining: case-CDF reweighted sampling for τ_z

### DIFF
--- a/case_cdf_sampler.py
+++ b/case_cdf_sampler.py
@@ -1,0 +1,348 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""H378 — Online hard-case mining: case-CDF reweighted sampling for τ_z.
+
+The dataset is indexed at the *view* level (each case is split into multiple
+point-limited views by ``DrivAerMLSurfaceDataset``); the sampler in this module
+operates at the *case* level and projects per-case weights onto per-view
+weights uniformly across that case's views.
+
+DDP pattern: rank 0 generates a global index list via ``torch.multinomial``,
+broadcasts to all ranks, then each rank slices ``[rank::world_size]``. This
+avoids the failure mode where independent per-rank ``WeightedRandomSampler``
+instances draw the same case onto multiple ranks in the same step.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import torch
+import torch.distributed as dist
+from torch.utils.data import Sampler
+
+
+# Mapping from channel spec strings to (modality, channel index).
+# "modality" is either "surface" (channel of the 4-dim surface_y tensor:
+# [cp, tau_x, tau_y, tau_z]) or "volume" (channel of the 1-dim volume_y
+# tensor: [volume_pressure]).
+CHANNEL_SPECS: dict[str, tuple[str, int]] = {
+    "sp": ("surface", 0),
+    "surface_pressure": ("surface", 0),
+    "wss_x": ("surface", 1),
+    "tau_x": ("surface", 1),
+    "wss_y": ("surface", 2),
+    "tau_y": ("surface", 2),
+    "wss_z": ("surface", 3),
+    "tau_z": ("surface", 3),
+    "vp": ("volume", 0),
+    "volume_pressure": ("volume", 0),
+}
+
+
+def parse_channel_spec(spec: str) -> list[tuple[str, int]]:
+    """Parse '--case-cdf-sampler-channels' into [(modality, channel_idx), ...]."""
+
+    parts = [token.strip() for token in spec.split(",") if token.strip()]
+    if not parts:
+        raise ValueError(f"--case-cdf-sampler-channels must list >=1 channel, got '{spec}'")
+    out: list[tuple[str, int]] = []
+    for token in parts:
+        key = token.lower()
+        if key not in CHANNEL_SPECS:
+            raise ValueError(
+                f"Unknown case-CDF channel '{token}'. Supported: {sorted(CHANNEL_SPECS)}"
+            )
+        out.append(CHANNEL_SPECS[key])
+    return out
+
+
+@dataclass
+class CaseCDFState:
+    """Per-epoch accumulator for case-level MAE on selected channels.
+
+    sum_abs: [N_cases, n_channels] sum of |pred - target| in normalized space.
+    count:   [N_cases, n_channels] number of valid (unmasked) point-channel
+             contributions accumulated.
+
+    Both tensors live on the training device for cheap in-place adds during
+    the batch loop, then are all-reduced at epoch end.
+    """
+
+    sum_abs: torch.Tensor
+    count: torch.Tensor
+    case_id_to_idx: dict[str, int]
+    channels: list[tuple[str, int]]
+
+    @classmethod
+    def init(
+        cls,
+        *,
+        case_ids: Sequence[str],
+        channels: list[tuple[str, int]],
+        device: torch.device,
+    ) -> "CaseCDFState":
+        n_cases = len(case_ids)
+        n_channels = len(channels)
+        return cls(
+            sum_abs=torch.zeros(n_cases, n_channels, device=device, dtype=torch.float64),
+            count=torch.zeros(n_cases, n_channels, device=device, dtype=torch.float64),
+            case_id_to_idx={cid: i for i, cid in enumerate(case_ids)},
+            channels=channels,
+        )
+
+    def reset(self) -> None:
+        self.sum_abs.zero_()
+        self.count.zero_()
+
+    @torch.no_grad()
+    def accumulate(
+        self,
+        *,
+        case_ids: Sequence[str],
+        surface_pred_norm: torch.Tensor,
+        surface_target_norm: torch.Tensor,
+        surface_mask: torch.Tensor,
+        volume_pred_norm: torch.Tensor,
+        volume_target_norm: torch.Tensor,
+        volume_mask: torch.Tensor,
+    ) -> None:
+        """Accumulate |pred - target| per (case, channel) in normalized space.
+
+        Normalized space is fine because all cases share the same
+        train-split normalization constants. The relative ranking of cases by
+        per-channel MAE is identical between normalized and original units.
+        """
+
+        surface_pred_norm = surface_pred_norm.detach().float()
+        surface_target_norm = surface_target_norm.detach().float()
+        volume_pred_norm = volume_pred_norm.detach().float()
+        volume_target_norm = volume_target_norm.detach().float()
+        surf_diff_abs = (surface_pred_norm - surface_target_norm).abs()
+        vol_diff_abs = (volume_pred_norm - volume_target_norm).abs()
+        for b, cid in enumerate(case_ids):
+            c_idx = self.case_id_to_idx.get(cid)
+            if c_idx is None:
+                continue
+            surf_valid = surface_mask[b]
+            vol_valid = volume_mask[b]
+            surf_n = int(surf_valid.sum().item())
+            vol_n = int(vol_valid.sum().item())
+            for ch_pos, (modality, ch) in enumerate(self.channels):
+                if modality == "surface":
+                    if surf_n == 0:
+                        continue
+                    s = surf_diff_abs[b, surf_valid, ch].sum().double()
+                    self.sum_abs[c_idx, ch_pos] += s
+                    self.count[c_idx, ch_pos] += float(surf_n)
+                else:  # volume
+                    if vol_n == 0:
+                        continue
+                    s = vol_diff_abs[b, vol_valid, ch].sum().double()
+                    self.sum_abs[c_idx, ch_pos] += s
+                    self.count[c_idx, ch_pos] += float(vol_n)
+
+    def all_reduce(self) -> None:
+        """Sum partial accumulators across DDP ranks (no-op if not distributed)."""
+
+        if dist.is_available() and dist.is_initialized():
+            dist.all_reduce(self.sum_abs, op=dist.ReduceOp.SUM)
+            dist.all_reduce(self.count, op=dist.ReduceOp.SUM)
+
+    def per_case_mae(self) -> torch.Tensor:
+        """Compute per-case mean absolute error averaged across the selected channels.
+
+        Returns: [N_cases] float64 tensor (on the same device as sum_abs).
+        Cases with zero contributions on every channel get MAE = 0; weight
+        normalization keeps them sampled at the eps floor so they are not
+        silently dropped.
+        """
+
+        per_channel_mae = self.sum_abs / self.count.clamp(min=1.0)
+        valid = (self.count > 0).double()
+        per_channel_mae = per_channel_mae * valid
+        denom = valid.sum(dim=1).clamp(min=1.0)
+        return per_channel_mae.sum(dim=1) / denom
+
+
+def compute_case_weights(
+    per_case_mae: torch.Tensor,
+    *,
+    alpha: float,
+    eps: float,
+    clip_factor: float,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Compute normalized per-case sampling weights with soft clipping.
+
+    Args:
+        per_case_mae: [N_cases] float tensor of per-case MAE (or any positive
+            hardness score).
+        alpha: priority exponent. alpha=0 → uniform (returns 1/N).
+        eps: numerical floor added before exponentiation to keep
+            zero-MAE cases samplable.
+        clip_factor: soft ceiling on per-case weight, expressed as a multiple
+            of the mean raw weight. Recommended 10-20 to bound ESS collapse
+            when one case dominates. Set to 0 or non-positive to disable.
+
+    Returns:
+        weights: [N_cases] normalized weights, sums to 1.
+        diagnostics: dict of scalars (ESS, entropy, min/max/median weight,
+            clip count).
+    """
+
+    p = per_case_mae.clamp(min=0.0).double()
+    n = p.numel()
+    if alpha == 0.0:
+        w = torch.full_like(p, 1.0 / float(n))
+        clip_active = 0
+    else:
+        w_raw = (p + eps) ** alpha
+        clip_active = 0
+        if clip_factor > 0.0:
+            # Soft cap relative to the MEDIAN raw weight. Median is robust
+            # to extreme outliers (which the cap is meant to constrain),
+            # so a single 1000x-overshooting case does not pull the cap
+            # threshold up to its own value.
+            median_raw = float(w_raw.median().item())
+            cap = float(clip_factor) * max(median_raw, 1e-30)
+            over = w_raw > cap
+            clip_active = int(over.sum().item())
+            if clip_active > 0:
+                w_raw = w_raw.clamp(max=cap)
+        w = w_raw / w_raw.sum().clamp(min=1e-30)
+    n = float(w.numel())
+    p_normalized = w  # by construction sums to 1
+    ess = float(1.0 / (p_normalized * p_normalized).sum().clamp(min=1e-30).item())
+    safe_log = (p_normalized.clamp(min=1e-30)).log()
+    entropy = float((-(p_normalized * safe_log)).sum().item())
+    entropy_uniform = float(torch.log(torch.tensor(n)).item())
+    diagnostics = {
+        "case_cdf/ess": ess,
+        "case_cdf/ess_frac": ess / n,
+        "case_cdf/entropy": entropy,
+        "case_cdf/entropy_uniform": entropy_uniform,
+        "case_cdf/entropy_ratio": entropy / max(entropy_uniform, 1e-30),
+        "case_cdf/w_min": float(p_normalized.min().item()),
+        "case_cdf/w_max": float(p_normalized.max().item()),
+        "case_cdf/w_median": float(p_normalized.median().item()),
+        "case_cdf/w_mean": float(p_normalized.mean().item()),
+        "case_cdf/clip_active": float(clip_active if alpha != 0.0 else 0),
+        "case_cdf/n_cases": float(n),
+    }
+    return w, diagnostics
+
+
+def case_to_view_weights(
+    case_weights: torch.Tensor,
+    case_id_to_idx: dict[str, int],
+    views: Iterable,  # iterable of PointView objects with `.case_id`
+) -> torch.Tensor:
+    """Project per-case weights onto per-view weights.
+
+    For each case c with weight w_c and v_c views, every view of c gets
+    view weight w_c / v_c so the total sampling mass of case c remains w_c
+    regardless of view count.
+    """
+
+    n_cases = case_weights.numel()
+    views_per_case = torch.zeros(n_cases, dtype=torch.float64)
+    case_idx_per_view: list[int] = []
+    for view in views:
+        c_idx = case_id_to_idx[view.case_id]
+        views_per_case[c_idx] += 1.0
+        case_idx_per_view.append(c_idx)
+    case_idx_tensor = torch.tensor(case_idx_per_view, dtype=torch.long)
+    cw_cpu = case_weights.detach().cpu().double()
+    per_case_share = cw_cpu / views_per_case.clamp(min=1.0)
+    view_weights = per_case_share[case_idx_tensor]
+    # WeightedRandomSampler tolerates zeros if any case has zero weight,
+    # but we want every case still potentially samplable, so floor at a
+    # tiny value relative to the mean. The weights themselves were already
+    # produced with an eps floor; this is belt-and-suspenders.
+    floor = 1e-12 * view_weights.mean().clamp(min=1e-30)
+    return view_weights.clamp(min=floor).double()
+
+
+class DistributedCaseCDFSampler(Sampler[int]):
+    """DDP-safe weighted view sampler driven by per-case weights.
+
+    Each ``__iter__`` call:
+      1. (rank 0) draws ``num_samples_total`` view indices via
+         ``torch.multinomial`` with the current ``view_weights``.
+      2. broadcasts the index tensor to all ranks.
+      3. each rank slices ``[rank::world_size]`` (interleaved shard) and
+         iterates its slice. Length per rank is exactly
+         ``num_samples_total // world_size`` so DDP batch counts stay aligned.
+
+    ``set_epoch(epoch)`` advances the deterministic generator seed so a
+    smoke run with the same ``--case-cdf-sampler-alpha 0.0`` and equal
+    weights is reproducible across epochs.
+
+    Weights are stored on CPU as float64 to dodge bfloat16 multinomial
+    instability; the actual sampling is also on CPU since multinomial
+    is generally cheap at this dataset size (~2000 views, 400 cases).
+    """
+
+    def __init__(
+        self,
+        *,
+        num_samples_total: int,
+        world_size: int,
+        rank: int,
+        seed: int = 0,
+        view_weights: torch.Tensor | None = None,
+    ):
+        if num_samples_total <= 0:
+            raise ValueError("num_samples_total must be positive")
+        if world_size <= 0:
+            raise ValueError("world_size must be positive")
+        if rank < 0 or rank >= world_size:
+            raise ValueError(f"rank {rank} not in [0, {world_size})")
+        # Round num_samples_total down to a multiple of world_size so each
+        # rank has the same number of samples (drop_last=True semantics).
+        self.num_samples_total = (num_samples_total // world_size) * world_size
+        if self.num_samples_total == 0:
+            self.num_samples_total = world_size
+        self.world_size = world_size
+        self.rank = rank
+        self.seed = int(seed)
+        self.epoch = 0
+        if view_weights is None:
+            raise ValueError("DistributedCaseCDFSampler requires initial view_weights")
+        self._view_weights = view_weights.detach().cpu().double().contiguous()
+
+    def __len__(self) -> int:
+        return self.num_samples_total // self.world_size
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = int(epoch)
+
+    @property
+    def view_weights(self) -> torch.Tensor:
+        return self._view_weights
+
+    def set_view_weights(self, view_weights: torch.Tensor) -> None:
+        if view_weights.numel() != self._view_weights.numel():
+            raise ValueError(
+                f"set_view_weights: expected {self._view_weights.numel()} values, "
+                f"got {view_weights.numel()}"
+            )
+        self._view_weights = view_weights.detach().cpu().double().contiguous()
+
+    def __iter__(self):
+        # All ranks generate identical indices using the same seed; this is
+        # both cheap (multinomial on a few-thousand-element distribution)
+        # and avoids any broadcast cost.
+        gen = torch.Generator(device="cpu")
+        gen.manual_seed(self.seed + 100003 * self.epoch)
+        indices = torch.multinomial(
+            self._view_weights,
+            self.num_samples_total,
+            replacement=True,
+            generator=gen,
+        )
+        my_slice = indices[self.rank :: self.world_size].tolist()
+        return iter(my_slice)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-**Updated**: 2026-06-02 13:00Z | Branch: `tay` | **SOTA: H342 3-cp output-avg ep13+ep14+ep15 × K=5 TTA — val_cal 5.8962 / test_cal 5.7357 (PR #1526 MERGED)**
+**Updated**: 2026-06-02 13:15Z | Branch: `tay` | **SOTA: H342 3-cp output-avg ep13+ep14+ep15 × K=5 TTA — val_cal 5.8962 / test_cal 5.7357 (PR #1526 MERGED)**
 
 ---
 
@@ -52,10 +52,11 @@
 | **RWPE-K16 Random Walk Positional Encoding (Finding U)** | `rwpe-surface-topology-pe-null` — Random-walk return probabilities up to K=16 hops on kNN-16 surface graph, 32-channel projection with zero-init. EP14 val_primary **6.0742%** (+5.7bp vs source, +2.4bp past 6.05% close rule). Per-channel: SP +18bp, VP +35bp, WSS_z +14bp (target channel WORSE), WSS ≈flat. Crashed mid-EP15 at step=8943 before grace-period evidence; original close rule applies. Joint with H348/H359/H360: **4 of 4 input-feature hypotheses null — input-feature axis CONCLUSIVELY EXHAUSTED on EP13 fine-tune basin**. **21st closed axis.** | **H369 CLOSED 12:08Z** |
 | **ISAB OPERATOR FAMILY CLOSED at single-layer bound (Finding V)** | `isab-single-layer-probe-null` — Single-layer ISAB at idx 2 (1-of-5 layers, M=32 inducing points). EP14 val_primary **6.7149%** (+70bp vs source, +66bp past 6.05% close rule). All 5 channels regressed broadly: SP +64bp, **VP +108bp (untouched-channel collapse)**, WSS +66bp, WSS_z +82bp. Same "basin lost calibrated slice-token interaction" signature as H370. **ISAB operator family CLOSED at the bound** — even one cold ISAB layer breaks token-count bijection enough to disrupt the pretrained surrounding layers under 3-epoch Lion cosine tail. **Implication: future operator replacements MUST preserve token-count bijection** — inducing-point/Perceiver-style bottleneck operators are empirically excluded from warm-start tier. **22nd closed axis.** | **H371 CLOSED 12:17Z** |
 | **kNN spatial-proximity attention bias (Finding W)** | `knn-spatial-proximity-attn-bias-null` — Zero-param additive pre-softmax attention bias from surface kNN proximity (k=32). EP14 val_primary **6.0752%** (>6.05% close rule, +1.6bp). Pre-committed close rule fired immediately; Phase 2 TTA skipped. 8 DDP ranks finished cleanly (rt~3.83h). **Geometric attention-bias signal fails.** Discriminator status: sets up H376 (physics-informed WSS-gradient magnitude bias) to distinguish geometry-only vs. physics-informed attention steering. If H376 also nulls, attention-steering tier is fully closed. **23rd closed axis.** | **H366 CLOSED 12:55Z** |
+| **Self-consistency τ_z-only vs EP13 EMA teacher (Finding X)** | `self-consistency-ep13-ema-teacher-null` — Frozen EP13 EMA teacher MSE consistency loss on τ_z channel only (λ=0.1). EP14 val_primary **6.0700%** (>6.00% kill gate). **ROOT CAUSE: teacher itself has ~9% WSS_z error** — Mean Teacher / NoRD prior requires teacher to have *lower* error than student, which is violated. Consistency penalty also propagated through shared backbone to other channels: WSS_y **+388bp** (worse than random initialization shift). Training-time τ_z regularization via bad teacher = noisy-target overfitting. **24th closed axis.** | **H374 PR #1569 CLOSED 13:00Z** |
 
 ---
 
-## Active Fleet (2026-06-02 13:00Z — 8/8 WIP, **all students assigned**)
+## Active Fleet (2026-06-02 13:15Z — 8/8 WIP, **all students assigned**)
 
 | PR | Student | Hypothesis | Status |
 |---|---|---|---|
@@ -66,13 +67,13 @@
 | **#1572** | tanjiro | **H376: WSS gradient-magnitude attention bias (EP13 EMA teacher, zero-param)** — Per-key additive attention bias proportional to ||∇τ_pred||₂ from frozen EP13 EMA teacher's WSS prediction over kNN-8 surface graph. Pre-compute once per sample; inject as static scalar into all slice-attention layers. Physics-informed successor to H366 (geometric kNN bias nulled as Finding W). Discriminator: if H376 also nulls, attention-steering tier CLOSED. Kill gate EP14 val>6.05%. ~14h+TTA. | 🟢 ASSIGNED 13:00Z |
 | **#1570** | fern | **H375: Cross-Channel Decoder Query Tokens** — K=4 learnable query tokens, cross-attention from τ_x/τ_y context → τ_z decoder. +0.1% params (264K @ d_model=512). Channels verified: loader.py:42 [...,1]=τ_x, [...,2]=τ_y, [...,3]=τ_z. Replaces wrong-premise H372 (z-mirror, closed no-run). Kill gate EP14 val>6.05%. ~14h+TTA. | 🟢 ASSIGNED 12:45Z |
 | **#1568** | frieren | **H373: Transolver++ Local Adaptive Slice Pooling** — Replace global slice softmax with k=16 kNN-constrained local pooling (temp=0.1). Zero params, preserves token-count bijection (post-H371 V constraint). Targets boundary-layer τ_z. Kill gate EP14 val>6.05%. ~14h+TTA. | 🟢 ASSIGNED 12:33Z |
-| **#1569** | edward | **H374: Self-Consistency vs EP13 EMA Teacher (τ_z-only, λ=0.1)** — Frozen EP13 teacher MSE consistency loss on τ_z channel only. Zero params, training-time regularizer. Anchors τ_z manifold drift on noisiest channel. Kill gate EP14 val>6.00%. ~10.5h+TTA. | 🟢 ASSIGNED 12:35Z |
+| **#1574** | edward | **H377: Z-antisymmetry mirrored augmentation (H-A)** — τ_z has strict algebraic antisymmetry τ_z(x,y,−z)=−τ_z(x,y,z) under lateral mirror. Train with z-mirrored batch copies (negate z-coord, nz, τ_z targets; batch_size=2 so mirror doubles back to 4 eff). Average τ_z at inference: 0.5×(pred_orig + (−pred_mirror)). Highest-priority unattacked symmetry axis. Zero params, zero architecture change. Kill gate EP14 val>6.00%. ~10.5h+TTA. | 🟢 ASSIGNED 13:15Z |
 
 ---
 
-## Current Research Focus: ATTENTION-STEERING TIER PARTIALLY CLOSED — GEOMETRIC NULL, PHYSICS-INFORMED PENDING
+## Current Research Focus: 24 CLOSED AXES — SYMMETRY AUGMENTATION NOW PRIMARY ATTACK (H377)
 
-**23 closed axes**. H366 closed (Finding W): geometric kNN proximity attention bias null (EP14 val 6.0752%, close-by-rule). H376 now tests whether *physics-informed* attention bias (EP13 EMA ||∇WSS|| magnitude per key) succeeds where pure geometry failed. Alongside H373/H374/H375 in the current live round, this is the narrowed frontier: (1) operator-pool architecture changes that preserve token-count bijection, (2) attention bias with physics-derived signals, (3) decoder cross-channel conditioning, (4) training-time regularization via teacher. Input-feature, loss, decoder-capacity, and ISAB-operator tiers all exhausted.
+**24 closed axes**. H374 closed (Finding X): self-consistency vs EP13 EMA teacher null — teacher has ~9% WSS_z error itself, violating the Mean Teacher premise. H366 (Finding W): geometric kNN proximity attention bias null. H376 now tests physics-informed attention bias; H377 (edward) tests z-antisymmetry mirrored augmentation — HIGHEST-priority remaining unattacked axis. H375/H373 in live round testing cross-channel decoder conditioning and local slice pooling. Narrowed frontier: (1) physical symmetry augmentation / equivariance constraints, (2) physics-informed attention bias, (3) decoder cross-channel conditioning, (4) operator replacements preserving token-count bijection. Training-time regularizer, input-feature, loss, decoder-capacity, and ISAB-operator tiers all exhausted.
 
 **SOTA CLUSTER UPDATE (post-H360 cal landing, 12:10Z):**
 | Arm | val_RAW | val_CAL | test_CAL | Status |

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,3 +1,23 @@
+## 2026-06-02 13:00Z — PR #1569: H374 Self-consistency τ_z-only vs frozen EP13 EMA teacher — CLOSED (pre-committed kill gate, Finding X)
+
+- Branch: edward/h374-self-consistency-ep13-ema-teacher
+- **Hypothesis**: Add a self-consistency regularization term L_consistency = λ × MSE(student_τ_z, teacher_τ_z.detach()) using a frozen EP13 EMA checkpoint as the teacher. Motivated by Mean Teacher / NoRD: a frozen good-epoch snapshot provides soft targets that can sharpen the student on the weakest channel (τ_z). λ=0.1, τ_z channel only, backbone unfrozen. Expected mechanism: regularization should reduce τ_z variance without perturbing the other channels.
+
+| Channel | H374 EP14 val | H336 EP13 baseline | Δ |
+|---|---:|---:|---:|
+| **val_abupt rel_l2_pct** | **6.0700%** | 6.017% | **+5.3bp** |
+| val_WSS_z | ~9.4% (est.) | ~9.06% | **+34bp** |
+| val_WSS_y | — | — | **+388bp regression** |
+
+- **Kill gate trigger**: EP14 val_primary 6.0700% > 6.00% hard kill gate → CLOSED immediately.
+- **Finding X** (24th closed axis): `self-consistency-ep13-ema-teacher-null`
+  - **Root cause**: EP13 EMA teacher has ~9% WSS_z error itself — the Mean Teacher / NoRD prior requires the teacher to have *lower* error than the student, which is violated here. The consistency target provides noisy supervision rather than regularization.
+  - **Backbone contamination**: Consistency penalty propagated through the shared backbone to untargeted channels. val_WSS_y **+388bp** regression — far worse than random initialization shift. This confirms the consistency gradient, despite targeting τ_z only, contaminated the entire backbone's internal representations via backprop.
+  - **Implication**: Training-time τ_z regularization via a bad teacher = noisy-target overfitting. Any Mean Teacher / NoRD variant requires a teacher with materially lower error on τ_z than the current student. Since EP13 is the best available checkpoint and the student is fine-tuning from EP13, no valid teacher exists within the current training protocol.
+  - **Closes "regularization via teacher"** hypothesis family: NoRD-style, EMA-soft-target, self-consistency on τ_z are all excluded under the current training protocol.
+
+---
+
 ## 2026-06-02 12:17Z — PR #1566: H371 ISAB single-layer probe at idx 2 — CLOSED (pre-committed close rule, Finding V) — ISAB OPERATOR FAMILY CLOSED at single-layer bound
 
 - Branch: edward/h371-isab-single-layer-idx2-probe

--- a/train.py
+++ b/train.py
@@ -32,6 +32,13 @@ from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
+from case_cdf_sampler import (
+    CaseCDFState,
+    DistributedCaseCDFSampler,
+    case_to_view_weights,
+    compute_case_weights,
+    parse_channel_spec,
+)
 from data import DrivAerMLSurfaceDataset
 from model import SurfaceTransolver
 from trainer_runtime import (
@@ -145,6 +152,13 @@ class Config:
     resume_alias: str = ""
     epochs_already_done: int = 0
     save_every_epoch: bool = False
+    # H378: online hard-case mining (case-CDF reweighted sampling)
+    case_cdf_sampler_alpha: float = 0.0
+    case_cdf_sampler_init: str = "uniform"
+    case_cdf_sampler_channels: str = "wss_z"
+    case_cdf_sampler_eps: float = 1e-6
+    case_cdf_sampler_clip: float = 15.0
+    case_cdf_sampler_seed: int = 1378
     debug: bool = False
 
 
@@ -271,6 +285,45 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "H244: save EMA checkpoint as 'checkpoint_ep{N}.pt' alongside "
             "the best-only checkpoint after every validation event. Used "
             "to keep EP14/15/16 EMA checkpoints for downstream TTA eval."
+        ),
+        "case_cdf_sampler_alpha": (
+            "H378: enable case-CDF reweighted sampling for online hard-case "
+            "mining. 0.0 = uniform sampling (baseline). 1.0 = linear "
+            "priority (Arm A). 2.0 = squared priority (Arm B, aggressive). "
+            "Per-case sampling weights w_i are computed from per-case "
+            "MAE_i on --case-cdf-sampler-channels and applied to the next "
+            "epoch's WeightedRandomSampler. With drop-last DDP semantics, "
+            "the per-rank batch count matches the baseline DistributedSampler."
+        ),
+        "case_cdf_sampler_init": (
+            "H378: how to seed sampler weights for the first epoch. "
+            "'uniform' = start with uniform per-case weights (cheap; lets "
+            "the first epoch be a baseline-style EP14, with mining "
+            "kicking in for EP15+). 'prefix-eval' = run one eval-style "
+            "forward pass over the train set before the first training "
+            "epoch and seed weights from that per-case MAE (more faithful "
+            "to the hypothesis when only 3 epochs remain)."
+        ),
+        "case_cdf_sampler_channels": (
+            "H378: comma-separated list of channels used to compute "
+            "per-case MAE for sampling priority. Supported: 'wss_z' "
+            "(tau_z, the H378 default), 'wss_y', 'wss_x', 'surface_pressure', "
+            "'volume_pressure'. Multi-channel specs average the per-channel "
+            "MAE per case before exponentiation."
+        ),
+        "case_cdf_sampler_eps": (
+            "H378: numerical floor added to MAE before exponentiation, "
+            "so zero-MAE cases remain samplable. Default 1e-6."
+        ),
+        "case_cdf_sampler_clip": (
+            "H378: soft cap on per-case weight expressed as a multiple of "
+            "the mean raw weight. Bounds ESS collapse when one case "
+            "dominates. Set to <=0 to disable. Default 15.0."
+        ),
+        "case_cdf_sampler_seed": (
+            "H378: base seed for the multinomial RNG used to draw view "
+            "indices each epoch. The actual per-epoch seed is "
+            "seed + 100003*epoch."
         ),
     }
     for field in fields(Config):
@@ -442,7 +495,8 @@ def train_loss(
     surface_loss_weight: float = 1.0,
     volume_loss_weight: float = 1.0,
     surface_channel_weights: torch.Tensor | None = None,
-) -> tuple[torch.Tensor, dict[str, float]]:
+    return_predictions: bool = False,
+) -> tuple[torch.Tensor, dict[str, float], dict[str, torch.Tensor] | None]:
     batch = batch.to(device)
     surface_target = transform.apply_surface(batch.surface_y)
     volume_target = transform.apply_volume(batch.volume_y)
@@ -467,13 +521,104 @@ def train_loss(
         weighted_volume_loss = volume_loss_weight * volume_loss
         loss = weighted_surface_loss + weighted_volume_loss
         base_mse_loss = surface_loss + volume_loss
-    return loss, {
+    metrics = {
         "base_mse_loss": float(base_mse_loss.detach().cpu().item()),
         "surface_loss": float(surface_loss.detach().cpu().item()),
         "volume_loss": float(volume_loss.detach().cpu().item()),
         "surface_loss_weighted": float(weighted_surface_loss.detach().cpu().item()),
         "volume_loss_weighted": float(weighted_volume_loss.detach().cpu().item()),
     }
+    extras: dict[str, torch.Tensor] | None = None
+    if return_predictions:
+        extras = {
+            "surface_pred_norm": out["surface_preds"].detach(),
+            "surface_target_norm": surface_target.detach(),
+            "volume_pred_norm": out["volume_preds"].detach(),
+            "volume_target_norm": volume_target.detach(),
+        }
+    return loss, metrics, extras
+
+
+def prefix_eval_fill_case_mae(
+    *,
+    model: nn.Module,
+    base_model: nn.Module,
+    train_case_ids: list[str],
+    config: "Config",
+    transform: TargetTransform,
+    device: torch.device,
+    state,
+    case_cdf_state: CaseCDFState,
+) -> None:
+    """H378: run one eval-style forward pass over the training cases and
+    fill ``case_cdf_state`` with per-case |pred - target| in normalized
+    space. Used to seed the case-CDF sampler before the first training
+    epoch (init mode 'prefix-eval').
+
+    Uses ``eval_chunk`` deterministic strided sampling so every training
+    point contributes to MAE exactly once, distributed across DDP ranks.
+    Returns without modifying model state.
+    """
+
+    from data.loader import DEFAULT_MANIFEST, DrivAerMLCaseStore
+
+    store = DrivAerMLCaseStore(
+        manifest_path=config.manifest,
+        root=config.data_root or None,
+    )
+    eval_surface = config.eval_surface_points or config.train_surface_points
+    eval_volume = config.eval_volume_points or config.train_volume_points
+    train_eval_ds = DrivAerMLSurfaceDataset(
+        train_case_ids,
+        store=store,
+        max_surface_points=eval_surface,
+        max_volume_points=eval_volume,
+        sampling_mode="eval_chunk",
+    )
+    sampler = None
+    if state.enabled:
+        from trainer_runtime import StridedDistributedSampler
+
+        sampler = StridedDistributedSampler(
+            train_eval_ds,
+            num_replicas=state.world_size,
+            rank=state.rank,
+        )
+    train_eval_loader = DataLoader(
+        train_eval_ds,
+        batch_size=config.batch_size,
+        shuffle=False,
+        sampler=sampler,
+        **loader_kwargs(config),
+    )
+    was_training = model.training
+    model.eval()
+    eval_module = unwrap_model(model)
+    try:
+        with torch.no_grad():
+            for batch in train_eval_loader:
+                batch = batch.to(device)
+                surface_target_norm = transform.apply_surface(batch.surface_y)
+                volume_target_norm = transform.apply_volume(batch.volume_y)
+                with autocast_context(device, config.amp_mode):
+                    out = eval_module(
+                        surface_x=batch.surface_x,
+                        surface_mask=batch.surface_mask,
+                        volume_x=batch.volume_x,
+                        volume_mask=batch.volume_mask,
+                    )
+                case_cdf_state.accumulate(
+                    case_ids=batch.case_ids,
+                    surface_pred_norm=out["surface_preds"],
+                    surface_target_norm=surface_target_norm,
+                    surface_mask=batch.surface_mask,
+                    volume_pred_norm=out["volume_preds"],
+                    volume_target_norm=volume_target_norm,
+                    volume_mask=batch.volume_mask,
+                )
+    finally:
+        if was_training:
+            model.train()
 
 
 GRADNORM_TASK_NAMES = ("sp", "tau_x", "tau_y", "tau_z", "vp")
@@ -1082,6 +1227,104 @@ def main(argv: Iterable[str] | None = None) -> None:
             wandb.summary["epochs_already_done"] = config.epochs_already_done
             wandb.summary["save_every_epoch"] = config.save_every_epoch
 
+        # H378: optional online case-CDF reweighted sampling. Active only
+        # when --case-cdf-sampler-alpha > 0; otherwise the existing
+        # DistributedSampler path is preserved unchanged.
+        case_cdf_state: CaseCDFState | None = None
+        case_cdf_sampler: DistributedCaseCDFSampler | None = None
+        if config.case_cdf_sampler_alpha > 0.0:
+            train_ds_handle = train_loader.dataset
+            case_ids_list = list(train_ds_handle.case_ids)
+            cdf_channels = parse_channel_spec(config.case_cdf_sampler_channels)
+            case_cdf_state = CaseCDFState.init(
+                case_ids=case_ids_list,
+                channels=cdf_channels,
+                device=device,
+            )
+            init_mode = config.case_cdf_sampler_init.lower()
+            if init_mode == "prefix-eval":
+                if state.is_main:
+                    print(
+                        f"H378: prefix-eval seeding sampler from per-case MAE "
+                        f"on channels={config.case_cdf_sampler_channels}"
+                    )
+                prefix_eval_fill_case_mae(
+                    model=model,
+                    base_model=base_model,
+                    train_case_ids=case_ids_list,
+                    config=config,
+                    transform=transform,
+                    device=device,
+                    state=state,
+                    case_cdf_state=case_cdf_state,
+                )
+                case_cdf_state.all_reduce()
+                init_mae = case_cdf_state.per_case_mae()
+            elif init_mode == "uniform":
+                init_mae = torch.zeros(
+                    len(case_ids_list), device=device, dtype=torch.float64
+                )
+            else:
+                raise ValueError(
+                    f"Unknown --case-cdf-sampler-init '{config.case_cdf_sampler_init}'. "
+                    f"Supported: 'uniform', 'prefix-eval'."
+                )
+            case_weights, init_diag = compute_case_weights(
+                init_mae,
+                alpha=config.case_cdf_sampler_alpha if init_mode == "prefix-eval" else 0.0,
+                eps=config.case_cdf_sampler_eps,
+                clip_factor=config.case_cdf_sampler_clip,
+            )
+            view_weights = case_to_view_weights(
+                case_weights,
+                case_cdf_state.case_id_to_idx,
+                train_ds_handle.views,
+            )
+            world_size = state.world_size if state.enabled else 1
+            rank = state.rank if state.enabled else 0
+            case_cdf_sampler = DistributedCaseCDFSampler(
+                num_samples_total=len(train_ds_handle.views),
+                world_size=world_size,
+                rank=rank,
+                seed=config.case_cdf_sampler_seed,
+                view_weights=view_weights,
+            )
+            train_loader = DataLoader(
+                train_ds_handle,
+                batch_size=config.batch_size,
+                shuffle=False,
+                sampler=case_cdf_sampler,
+                drop_last=True,
+                **loader_kwargs(config),
+            )
+            # Reset accumulator: prefix-eval data was for sampler init only;
+            # actual EP14 training-time per-case MAE is a fresh accumulation.
+            case_cdf_state.reset()
+            if state.is_main:
+                init_log = {
+                    "case_cdf/init_mode_uniform": float(init_mode == "uniform"),
+                    "case_cdf/init_mode_prefix_eval": float(init_mode == "prefix-eval"),
+                    "case_cdf/alpha": config.case_cdf_sampler_alpha,
+                    "case_cdf/eps": config.case_cdf_sampler_eps,
+                    "case_cdf/clip_factor": config.case_cdf_sampler_clip,
+                    "case_cdf/num_views_total": float(len(train_ds_handle.views)),
+                    "case_cdf/per_rank_views_per_epoch": float(len(case_cdf_sampler)),
+                    **{f"case_cdf/init/{k.split('/', 1)[-1]}": v for k, v in init_diag.items()},
+                }
+                wandb.summary["case_cdf/alpha"] = config.case_cdf_sampler_alpha
+                wandb.summary["case_cdf/init_mode"] = init_mode
+                wandb.summary["case_cdf/channels"] = config.case_cdf_sampler_channels
+                wandb.summary["case_cdf/eps"] = config.case_cdf_sampler_eps
+                wandb.summary["case_cdf/clip_factor"] = config.case_cdf_sampler_clip
+                wandb.log(init_log)
+                print(
+                    f"H378: case-CDF sampler enabled "
+                    f"(alpha={config.case_cdf_sampler_alpha}, init={init_mode}, "
+                    f"channels={config.case_cdf_sampler_channels}, "
+                    f"ESS={init_diag['case_cdf/ess']:.1f}/"
+                    f"{int(init_diag['case_cdf/n_cases'])})"
+                )
+
         best_val = float("inf")
         best_metrics: dict[str, float] = {}
         best_checkpoint_source = "ema" if ema is not None else "raw"
@@ -1110,6 +1353,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                     current_train_vol_points = desired_vol_points
             if isinstance(train_loader.sampler, DistributedSampler):
+                train_loader.sampler.set_epoch(epoch)
+            elif isinstance(train_loader.sampler, DistributedCaseCDFSampler):
                 train_loader.sampler.set_epoch(epoch)
             timeout_hit = distributed_any(
                 state,
@@ -1221,7 +1466,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                     if gradnorm_loss_tensor is not None:
                         gradnorm_metrics["gradnorm/loss"] = float(gradnorm_loss_tensor.cpu().item())
                 else:
-                    loss, batch_loss_metrics = train_loss(
+                    loss, batch_loss_metrics, train_loss_extras = train_loss(
                         model,
                         batch,
                         transform,
@@ -1230,7 +1475,18 @@ def main(argv: Iterable[str] | None = None) -> None:
                         surface_loss_weight=config.surface_loss_weight,
                         volume_loss_weight=config.volume_loss_weight,
                         surface_channel_weights=surface_channel_weights if use_channel_weights else None,
+                        return_predictions=case_cdf_state is not None,
                     )
+                    if case_cdf_state is not None and train_loss_extras is not None:
+                        case_cdf_state.accumulate(
+                            case_ids=batch.case_ids,
+                            surface_pred_norm=train_loss_extras["surface_pred_norm"],
+                            surface_target_norm=train_loss_extras["surface_target_norm"],
+                            surface_mask=batch.surface_mask.to(device),
+                            volume_pred_norm=train_loss_extras["volume_pred_norm"],
+                            volume_target_norm=train_loss_extras["volume_target_norm"],
+                            volume_mask=batch.volume_mask.to(device),
+                        )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
                 current_lr = scheduler.get_last_lr()[0]
@@ -1375,6 +1631,40 @@ def main(argv: Iterable[str] | None = None) -> None:
                 or (timeout_hit and n_batches > 0)
             )
 
+            # H378: build the next-epoch case-CDF sampler from this epoch's
+            # per-case MAE accumulator, then reset for the next epoch.
+            case_cdf_epoch_log: dict[str, float] = {}
+            if case_cdf_state is not None and case_cdf_sampler is not None:
+                case_cdf_state.all_reduce()
+                per_case_mae = case_cdf_state.per_case_mae()
+                next_case_weights, weight_diag = compute_case_weights(
+                    per_case_mae,
+                    alpha=config.case_cdf_sampler_alpha,
+                    eps=config.case_cdf_sampler_eps,
+                    clip_factor=config.case_cdf_sampler_clip,
+                )
+                next_view_weights = case_to_view_weights(
+                    next_case_weights,
+                    case_cdf_state.case_id_to_idx,
+                    train_loader.dataset.views,
+                )
+                case_cdf_sampler.set_view_weights(next_view_weights)
+                if state.is_main:
+                    per_case_mae_cpu = per_case_mae.detach().cpu()
+                    case_cdf_epoch_log.update(weight_diag)
+                    case_cdf_epoch_log.update(
+                        {
+                            "case_cdf/mae_min": float(per_case_mae_cpu.min().item()),
+                            "case_cdf/mae_max": float(per_case_mae_cpu.max().item()),
+                            "case_cdf/mae_mean": float(per_case_mae_cpu.mean().item()),
+                            "case_cdf/mae_median": float(per_case_mae_cpu.median().item()),
+                            "case_cdf/n_cases_seen": float(
+                                (case_cdf_state.count.sum(dim=1) > 0).sum().item()
+                            ),
+                        }
+                    )
+                case_cdf_state.reset()
+
             log_metrics: dict[str, object] = {
                 "train/epoch_loss": epoch_train_loss,
                 "train/lr": scheduler.get_last_lr()[0],
@@ -1382,6 +1672,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 "epoch_time_s": dt,
                 "global_step": global_step,
             }
+            if case_cdf_epoch_log:
+                log_metrics.update(case_cdf_epoch_log)
             if early_stop_reason is not None:
                 log_metrics["early_stop/triggered"] = 1.0
                 wandb.log(log_metrics)


### PR DESCRIPTION
## Hypothesis

WSS_z floor remains at test_WSS_z = 8.6122% (H342 SOTA) vs Transolver-3 target < 5.85%. **Edward has nullified 7 consecutive axes targeting τ_z**, all operating at vertex-level or operator-level:
- H338 (SP-loss-reweight), H361 (direction-magnitude WSS), H364 (target-magnitude WSS hotspot)
- H368 (WSS spatial-gradient consistency loss), H370 (ISAB 3-of-5 middle layers), H371 (ISAB single-layer probe)
- H374 (self-consistency EP13 EMA teacher τ_z-only)

**Case-level reweighting has NOT been attacked**. This hypothesis tests the distribution-level lever: per-epoch, compute per-case τ_z MAE; reweight the case-sampling distribution next epoch by `p_i ∝ MAE_i^α`. The model spends more gradient time on cases with high τ_z error.

**Mechanistically distinct from edward's 7 prior nulls**:
- Loss-tier nulls (H338/H361/H364/H368) all changed per-VERTEX gradient magnitudes within each case — closed.
- Operator-tier nulls (H370/H371) replaced slice-mixing layers — closed.
- Regularizer-tier null (H374) added a per-vertex MSE consistency loss — closed.
- **H378 changes which CASES the model sees and at what frequency** — a data-distribution lever, not a loss-formula or architecture lever.

**Risk**: 400-sample dataset is small. Aggressive α may oversample 4-6 hard geometries and overfit. Mitigation: Arm A α=1.0 (mild); Arm B α=2.0 only if Arm A passes EP14 kill gate.

**Discriminator outcomes**:
- val_WSS_z drops ≥30bp at EP14 (val_primary stays ≤ 6.05%) → case-level mining is a real lever; Arm B α=2 worth chasing.
- val_primary regresses past 6.05% → mining destroys multi-channel balance (same Lion-basin signature as H364/H368).
- val_primary neutral, val_WSS_z neutral → 25th closed axis (case-level distribution-shift tier closes).

## Instructions

**Smoke first (~10min, optional)**: implement the flag with `--case-cdf-sampler-alpha 0.0` (uniform) and confirm 1-epoch identical to baseline EP14 step-by-step (same train loss, same val_primary). Then launch primary.

**Code changes in `train.py`**:

1. Add CLI flags:
   - `--case-cdf-sampler-alpha` (float, default 0.0). When >0, replace the standard `RandomSampler` with `WeightedRandomSampler`.
   - `--case-cdf-sampler-init` (str, default "uniform"). Options: `"uniform"` (all w=1.0 for EP14, update from EP14 stats for EP15+) or `"prefix-eval"` (run 1-pass eval on training set before EP14 to compute initial MAE; ~5min for 400 cases on 8 GPU).
   - `--case-cdf-sampler-channels` (str, default "wss_z"). Channels to compute MAE over. Use `"wss_z"` only for this experiment.

2. After each training epoch, in the main training loop:
   - Accumulate per-case `mean abs(pred_τ_z − target_τ_z)` over all vertices in each training case.
   - Reduce across DDP ranks (all-reduce SUM, then divide by per-case point count).
   - Compute weights for next epoch: `w_i = MAE_i ** alpha + eps`, then `w_i /= sum(w_j)` and pass `num_samples=400`, `replacement=True` to a new `WeightedRandomSampler`.
   - Log per-case sampling probability statistics (entropy, min/max/median weight) every epoch.

3. **Use DDP with 8 GPUs**.

4. **Use the same warm-start pattern as your H368/H370/H371/H374 experiments** (`--warmstart-from-wandb 3icmxaqe --warmstart-from-epoch 13 --epochs-already-done 13 --epochs 16 --lr 1e-4 --lr-min 1e-6 --lr-cosine-t-max 3 --optimizer lion --tau-y-loss-weight 1.3`). Run `python train.py --help` to confirm exact flag spellings — use hyphenated forms.

**Arm A primary (α=1.0)**:

```bash
torchrun --nproc_per_node=8 train.py \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --warmstart-from-wandb 3icmxaqe \
  --warmstart-from-epoch 13 \
  --epochs-already-done 13 \
  --epochs 16 \
  --lr 1e-4 \
  --lr-min 1e-6 \
  --lr-cosine-t-max 3 \
  --bs 4 \
  --optimizer lion \
  --tau-y-loss-weight 1.3 \
  --case-cdf-sampler-alpha 1.0 \
  --case-cdf-sampler-init prefix-eval \
  --case-cdf-sampler-channels wss_z \
  --wandb-group h378-edward-case-mining-arma
```

**Arm B aggressive (α=2.0)** — launch ONLY if Arm A passes EP14 kill gate:

```bash
... (same args, replace) --case-cdf-sampler-alpha 2.0 --wandb-group h378-edward-case-mining-armb
```

**TTA cascade after Arm A passes**: if EP14/EP15/EP16 SENPAI-RESULT shows val_primary RAW < 6.00% AND val_WSS_z RAW < 9.20%, run the H342 3-cp × K=5 TTA + OLS cal cascade as Arm C (use `tools/h342_avg_checkpoints.py` if exists; otherwise replicate H342's TTA pipeline). Target: val_cal < 5.8962 AND test_cal < 5.7357.

## Kill gates (pre-committed, do NOT extend)

- **Arm A EP14 val_primary > 6.05%** → close PR with Finding Y close-tag. Skip Arm B. Skip TTA.
- **Arm A EP14 val_WSS_z > 9.30%** → close with Finding Y. Skip Arm B (target channel didn't move + general regression risk).
- Both must NOT trigger to chain Arm B.

## Baseline (H342, PR #1526 MERGED 2026-06-01)

- **val_cal**: 5.8962%
- **test_cal**: 5.7357%
- **test_WSS_z**: 8.6122% (primary obstacle — 0.762pp gap to 5.85% target)
- **test_VP**: 3.3751% / **test_SP**: 3.6124%
- **W&B SOTA**: `3icmxaqe` (3-cp output-avg ep13+ep14+ep15 × K=4)
- **Reproduce baseline**: see `BASELINE.md` head section

**Merge gate** (AND-logic, strict):
- val_cal < **5.8962%** AND test_cal < **5.7357%**

## Reporting

Post terminal SENPAI-RESULT marker when terminal:
```
SENPAI-RESULT: {"terminal":true,"status":"<complete|closed>","pending_arms":false,"wandb_run_ids":["<arm-a-id>","<arm-b-id?>"],"primary_metric":{"name":"val_abupt_calibrated","value":<float>},"test_metric":{"name":"test_abupt_calibrated","value":<float>}}
```

Include per-channel breakdown and any diagnostic plots (per-case sampling probability evolution, weight distribution entropy over epochs).
