### PR TITLE
H379: Per-layer LR decay (PEFT-style) — backbone×0.3, decoder×1.0

### DIFF
--- a/train.py
+++ b/train.py
@@ -146,6 +146,10 @@ class Config:
     epochs_already_done: int = 0
     save_every_epoch: bool = False
     debug: bool = False
+    # H379: per-layer LR decay (PEFT-style) for fine-tune tails
+    use_layerwise_lr_decay: bool = False
+    backbone_lr_scale: float = 1.0
+    decoder_lr_scale: float = 1.0
 
 
 def parse_args(argv: Iterable[str] | None = None) -> Config:
@@ -272,6 +276,27 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
             "the best-only checkpoint after every validation event. Used "
             "to keep EP14/15/16 EMA checkpoints for downstream TTA eval."
         ),
+        "use_layerwise_lr_decay": (
+            "H379: enable PEFT-style per-layer LR decay. When True, params "
+            "are partitioned into a backbone group (everything except "
+            "surface_out.*) and a decoder group (surface_out.* — the "
+            "4-channel surface head). Each group's base LR is scaled by "
+            "--backbone-lr-scale and --decoder-lr-scale respectively, then "
+            "passes through the standard cosine/warmup scheduler. Used to "
+            "test whether asymmetric LR preserves a well-pretrained "
+            "backbone while letting the surface decoder specialize during "
+            "a short fine-tune tail."
+        ),
+        "backbone_lr_scale": (
+            "H379: scale applied to --lr for the backbone param group when "
+            "--use-layerwise-lr-decay is True. Default 1.0 (no scaling). "
+            "Recommended 0.3 for PEFT-style fine-tune tails."
+        ),
+        "decoder_lr_scale": (
+            "H379: scale applied to --lr for the surface decoder param "
+            "group when --use-layerwise-lr-decay is True. Default 1.0 "
+            "(matches base LR)."
+        ),
     }
     for field in fields(Config):
         value = getattr(defaults, field.name)
@@ -286,8 +311,95 @@ def parse_args(argv: Iterable[str] | None = None) -> Config:
     return Config(**vars(namespace))
 
 
+def _split_param_groups_for_lr_decay(
+    model: nn.Module,
+    config: Config,
+) -> tuple[list[dict], dict[str, int]]:
+    """H379: partition trainable params into backbone vs surface-decoder groups.
+
+    Decoder group = params under ``surface_out.*`` (the 4-channel surface
+    head: cp, tau_x, tau_y, tau_z). Backbone group = everything else,
+    including the volume head, the Transolver attention stack, slice
+    modules, RFF/string_sep encodings, bias MLPs, and the final LayerNorm.
+    """
+
+    decoder_params: list[nn.Parameter] = []
+    backbone_params: list[nn.Parameter] = []
+    decoder_names: list[str] = []
+    backbone_names: list[str] = []
+    for name, param in model.named_parameters():
+        if not param.requires_grad:
+            continue
+        # Strip DDP / OptimizedModule wrappers from the path.
+        cleaned = name.replace("module.", "").replace("_orig_mod.", "")
+        if cleaned.startswith("surface_out."):
+            decoder_params.append(param)
+            decoder_names.append(cleaned)
+        else:
+            backbone_params.append(param)
+            backbone_names.append(cleaned)
+
+    if not decoder_params:
+        raise RuntimeError(
+            "H379 layerwise LR decay: no parameters matched 'surface_out.*' — "
+            "model partition is empty. Check that the model exposes the "
+            "expected surface decoder prefix."
+        )
+
+    backbone_count = sum(p.numel() for p in backbone_params)
+    decoder_count = sum(p.numel() for p in decoder_params)
+    partition_info = {
+        "backbone_params": backbone_count,
+        "decoder_params": decoder_count,
+        "backbone_tensors": len(backbone_params),
+        "decoder_tensors": len(decoder_params),
+    }
+    groups = [
+        {
+            "params": backbone_params,
+            "lr": config.lr * config.backbone_lr_scale,
+            "name": "backbone",
+        },
+        {
+            "params": decoder_params,
+            "lr": config.lr * config.decoder_lr_scale,
+            "name": "decoder",
+        },
+    ]
+    return groups, partition_info
+
+
 def build_optimizer(model: nn.Module, config: Config) -> torch.optim.Optimizer:
     optimizer_name = config.optimizer.lower()
+    if config.use_layerwise_lr_decay:
+        groups, partition_info = _split_param_groups_for_lr_decay(model, config)
+        total = partition_info["backbone_params"] + partition_info["decoder_params"]
+        if total > 0:
+            decoder_frac = partition_info["decoder_params"] / total
+            print(
+                f"[H379] layerwise LR decay enabled: "
+                f"backbone={partition_info['backbone_params']:,} params "
+                f"({partition_info['backbone_tensors']} tensors) @ lr×{config.backbone_lr_scale}; "
+                f"decoder={partition_info['decoder_params']:,} params "
+                f"({partition_info['decoder_tensors']} tensors) @ lr×{config.decoder_lr_scale} "
+                f"(decoder fraction={decoder_frac:.4f})",
+                flush=True,
+            )
+        if optimizer_name == "adamw":
+            return torch.optim.AdamW(groups, weight_decay=config.weight_decay)
+        if optimizer_name == "lion":
+            from lion_pytorch import Lion
+
+            return Lion(
+                groups,
+                weight_decay=config.weight_decay,
+                betas=(config.lion_beta1, config.lion_beta2),
+                use_triton=False,
+            )
+        raise ValueError(
+            f"Unknown optimizer '{config.optimizer}'. Supported: adamw, lion."
+        )
+
     if optimizer_name == "adamw":
         return torch.optim.AdamW(
             model.parameters(),
@@ -1233,7 +1345,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                     )
                 optimizer.zero_grad(set_to_none=True)
                 global_step += 1
-                current_lr = scheduler.get_last_lr()[0]
+                last_lrs = scheduler.get_last_lr()
+                current_lr = last_lrs[0]
                 loss_is_nonfinite = not bool(torch.isfinite(loss.detach()).item())
                 skip_step = distributed_any(state, loss_is_nonfinite, device)
                 should_log_model_telemetry = (
@@ -1257,6 +1370,12 @@ def main(argv: Iterable[str] | None = None) -> None:
                     "train/step_skipped": 1.0 if skip_step else 0.0,
                     "train/nonfinite_loss": 1.0 if loss_is_nonfinite else 0.0,
                 }
+                if config.use_layerwise_lr_decay:
+                    for group_idx, group in enumerate(optimizer.param_groups):
+                        group_name = group.get("name", f"group{group_idx}")
+                        if group_idx < len(last_lrs):
+                            train_log[f"train/lr_{group_name}"] = float(last_lrs[group_idx])
+                        train_log[f"train/lr_{group_name}_current"] = float(group["lr"])
                 if not loss_is_nonfinite:
                     train_log.update(
                         {
@@ -1375,13 +1494,19 @@ def main(argv: Iterable[str] | None = None) -> None:
                 or (timeout_hit and n_batches > 0)
             )
 
+            epoch_last_lrs = scheduler.get_last_lr()
             log_metrics: dict[str, object] = {
                 "train/epoch_loss": epoch_train_loss,
-                "train/lr": scheduler.get_last_lr()[0],
-                "lr": scheduler.get_last_lr()[0],
+                "train/lr": epoch_last_lrs[0],
+                "lr": epoch_last_lrs[0],
                 "epoch_time_s": dt,
                 "global_step": global_step,
             }
+            if config.use_layerwise_lr_decay:
+                for group_idx, group in enumerate(optimizer.param_groups):
+                    group_name = group.get("name", f"group{group_idx}")
+                    if group_idx < len(epoch_last_lrs):
+                        log_metrics[f"train/lr_{group_name}"] = float(epoch_last_lrs[group_idx])
             if early_stop_reason is not None:
                 log_metrics["early_stop/triggered"] = 1.0
                 wandb.log(log_metrics)


### PR DESCRIPTION
## Hypothesis

**Apply per-layer learning rate decay (PEFT-style) during the 3-epoch fine-tune tail: backbone layers receive `lr × 0.3`, surface decoder receives `lr × 1.0`. Test whether silent backbone catastrophic forgetting is limiting the EP14-EP16 fine-tune basin from finding lower val_primary / val_WSS_z.**

### Why this is mechanistically distinct from all 24+ closed axes (now 25 with your H375 close)

The 25 closed axes attacked the loss formulation (7 nulls), input features (5 nulls), encoder operators (6 nulls), decoder capacity (4 nulls), regularization (2 nulls), gradient surgery (1 null), and self-consistency. **None of them tested the LEARNING RATE STRUCTURE on the fine-tune trajectory.** Every experiment used a uniform-LR fine-tune which means the well-pretrained backbone (13 epochs of cosine-LR training to H342 SOTA) is being updated with the SAME LR as a freshly-warmstarted decoder head. Under Lion's sign-based updates, large LR + warm-started parameters = drift; small LR + new parameters = under-fit.

**Hypothesis**: H336 EP13 EMA encodes a well-tuned multi-channel basin. The 3-epoch cosine tail at uniform lr=9e-5 with `weight_decay=5e-4` is destructively eroding backbone features (the 13-layer Transolver backbone has highly-tuned slice attention + RFF + cross-attention modules) while only marginally improving the surface decoder. Under PEFT-style asymmetric LR scaling, the backbone is preserved (LR×0.3, effectively a slow drift) while the decoder gets full LR to specialize. This is the standard PEFT recipe (LoRA/AdaLoRA/Layerwise-LR papers) for fine-tuning pretrained models without forgetting.

Cross-validates with **fern's own diagnostic on H375**: "Lion uses sign(grad) updates, which means the learning rate effectively determines absolute step size regardless of grad magnitude. New zero-init or near-zero-init parameters take large early steps under Lion that may overshoot the basin." That observation directly motivates: if Lion's sign-update is the issue for new params, then partitioning LR by parameter age (backbone=well-tuned, decoder=fine-tuning target) should help.

### Empirical grounding

- **Layer-wise LR decay**: standard practice in NLP fine-tuning (BERT, RoBERTa, T5); typically backbone-LR / decoder-LR ratio of 0.1–0.5 gives 2–5% downstream-task gains. Application to PDE-surrogate fine-tuning is novel.
- **LoRA / PEFT family** (Hu et al., ICLR 2022; Liu et al., NeurIPS 2022): freezing or low-LR-updating the backbone preserves pretrained features while task-specific adapters specialize.
- **Adam-style adaptive LR vs uniform LR**: Lion-paper recommends 3-10× lower LR than AdamW. Lion at uniform 9e-5 across a 13-layer pretrained backbone + fresh decoder is likely sub-optimal for the heterogeneous-age parameter mix.
- **Closest CFD-surrogate precedent**: GINO (Li et al., NeurIPS 2023) trains operator + decoder with separate LR schedules; reports +5–8% rel L2 reduction.

### Expected outcomes

- **Positive (target)**: val_WSS_z drops ≥30bp at EP15-EP16, val_primary unchanged or lower, **with no destabilization of other channels** (this is the key discriminator vs H375 where ALL channels regressed). If τ_x/τ_y/p_s/p_v stay at H342 levels while WSS_z improves, the backbone-forgetting hypothesis is confirmed and we have a new SOTA candidate.
- **Negative**: val_primary > 6.05% at EP14 → CLOSE per pre-committed kill rule. If backbone forgetting isn't the bottleneck, the τ_z floor is determined by representation capacity, not training dynamics.

## Instructions

**Branch:** `fern/h379-glu-output-head` (already created — **note: branch name is from earlier draft, hypothesis is per-layer LR scaling, not GLU**)

### Step 1 — Add CLI flags to `target/train.py`

```
--use-layerwise-lr-decay True        # NEW: enable per-layer LR decay
--backbone-lr-scale 0.3              # backbone effective LR = base_lr × 0.3
--decoder-lr-scale 1.0               # decoder effective LR = base_lr × 1.0
```

Default behavior (when `--use-layerwise-lr-decay False`): identical to current uniform-LR optimizer (no behavior change for other experiments).

### Step 2 — Implement optimizer param-group split

In the optimizer construction (likely in `train.py` where `lion = Lion(...)` or similar):

1. Inspect `model.named_parameters()` and partition into:
   - **Decoder group**: any param whose name matches the surface output head MLP / projection layers. Look for prefixes like `surface_decoder.`, `surface_out.`, `to_surface.`, `head.surface.`, or whichever exists in the model. The 4-channel output head (cp, τ_x, τ_y, τ_z) and any intermediate decoder MLPs go here.
   - **Backbone group**: everything else (Transolver layers, attention, slice modules, embeddings, RFF, normalizations).

2. Build Lion optimizer with two param groups:
   ```python
   optimizer = Lion(
       [
           {"params": backbone_params, "lr": base_lr * args.backbone_lr_scale},
           {"params": decoder_params, "lr": base_lr * args.decoder_lr_scale},
       ],
       weight_decay=5e-4,
       betas=(0.9, 0.99),
   )
   ```

3. **The cosine LR scheduler must respect param groups** — `torch.optim.lr_scheduler.CosineAnnealingLR` does this natively (each group's `initial_lr` is preserved, cosine multiplier applies to all groups). Verify after construction that `scheduler.base_lrs == [base_lr*0.3, base_lr*1.0]`.

4. **W&B logging**: log per-group effective LR at every step:
   ```python
   wandb.log({"train/lr_backbone": optimizer.param_groups[0]["lr"],
              "train/lr_decoder": optimizer.param_groups[1]["lr"]})
   ```
   This is the smoke test — verify in W&B at step 0 that backbone_lr = 2.7e-5 and decoder_lr = 9e-5.

### Step 3 — Smoke check (2-epoch debug, batch_size=4, no warm-start, just verifying param-group split is correct)

```bash
torchrun --standalone --nproc-per-node=8 train.py \
  --epochs 2 --debug \
  --use-layerwise-lr-decay True --backbone-lr-scale 0.3 --decoder-lr-scale 1.0 \
  --optimizer lion --lr 9e-5 --weight-decay 5e-4 \
  --wandb-group h379-fern-smoke \
  --wandb-name "fern/h379-smoke-layerwise-lr"
```

Verify in W&B:
- `train/lr_backbone` at step 0 = 2.7e-5
- `train/lr_decoder` at step 0 = 9.0e-5
- Both decay together via cosine; ratio backbone/decoder stays at 0.3 throughout
- N decoder params + N backbone params = N total params (no leakage, no duplicates)
- Log the decoder param count vs backbone param count (`sum(p.numel() for p in group)` per group) — sanity check the partition makes sense (decoder should be ~1–5% of total).

### Step 4 — Phase 1 (H336 EP13 EMA warm-start, 3-epoch cosine tail, 8 GPUs DDP)

```bash
H185_EP13_EMA="outputs/ensemble_cache/run-yw2a5dyl-epoch-13-ema/checkpoint.pt"

torchrun --standalone --nproc-per-node=8 train.py \
  --resume-from-wandb yw2a5dyl --resume-alias epoch-13 \
  --epochs-already-done 0 --epochs 3 \
  --optimizer lion --lr 9e-5 --lr-cosine-t-max 3 --lr-min 1e-6 \
  --weight-decay 5e-4 --batch-size 4 \
  --tau-y-loss-weight 1.3 --tau-z-loss-weight 1.67 \
  --surface-loss-weight 2.0 --volume-loss-weight 0.5 \
  --grad-clip-norm 0.5 --ema-decay 0.999 \
  --use-qk-norm --rff-num-features 16 --pos-encoding-mode string_separable \
  --model-layers 5 --model-hidden-dim 512 --model-heads 4 --model-slices 128 \
  --mirror-augmentation \
  --use-layerwise-lr-decay True --backbone-lr-scale 0.3 --decoder-lr-scale 1.0 \
  --vol-points-schedule "0:65536" \
  --train-surface-points 65536 --train-volume-points 65536 \
  --eval-surface-points 65536 --eval-volume-points 65536 \
  --save-every-epoch --no-compile-model \
  --kill-thresholds "2720:val_primary/abupt_axis_mean_rel_l2_pct>6.05" \
  --data-root /mnt/new-pvc/Processed/drivaerml_processed_rawcanon_20260511 \
  --wandb-group h379-fern-layerwise-lr \
  --wandb-name "fern/h379-phase1-layerwise-lr-decay-0.3"
```

**Note**: pass `--kill-thresholds` this time per your H375 process note — auto-kill at EP14 if val_primary > 6.05%.

### Pre-committed kill rules

- **EP14 val_primary > 6.05%** → CLOSE immediately
- **EP14 ANY of (val_p_s, val_p_v, val_WSS, val_WSS_x, val_WSS_y) regressed by ≥30bp vs H336 EP13 EMA source baseline** → CLOSE (same broad-disruption signature your H375 caught)
- **EP14 val_primary ≤ 6.05% AND val_WSS_z drops ≥20bp vs H336 EP13 source AND no other channel regressed >10bp** → continue to EP15/EP16 + Phase 2 TTA

### Step 5 — TTA cascade (if Phase 1 passes EP14 gate)

Same H336 TTA recipe (K=5 + Student-t ν=4 + 8-res + mirror + per-channel cal) on best-val checkpoint, then test split. Reproduce the eval_tta_h252 command from your H375 PR with `--checkpoint <best_ckpt.pt>`.

## Baseline

**Current SOTA H342 (PR #1526, MERGED):**
- val_abupt_calibrated = **5.8962%**
- test_abupt_calibrated = **5.7357%**
- test_VP = 3.3751%, test_SP = 3.6124%, test_WSS = 6.6351%, **test_WSS_z = 8.6122%**

**Merge gate (strict AND):** val_cal < 5.8962% AND test_cal < 5.7357%

**Estimated wall-clock:** ~3.5h/epoch × 3 epochs = ~10.5h Phase 1. TTA cascade ~7h. Total ~17.5h, under SENPAI_TIMEOUT_MINUTES=540 cap.

**References:**
1. Devlin et al., BERT (2019) — layer-wise LR decay as standard NLP fine-tuning recipe
2. Hu et al., LoRA (ICLR 2022) — backbone preservation via low-rank adapters; same principle
3. Li et al., GINO (NeurIPS 2023) — separate backbone/decoder LR schedules in PDE surrogates

**Constraints:**
- DDP×8 mandatory
- τ_z normalization LOCKED at 1.67 (never modify)
- Read-only: `data/loader.py`, `data/preload.py`, `data/split_manifest.json`
- Zero new parameters (only optimizer config changes)
- Token-count bijection preserved (no architectural change, Finding V satisfied trivially)
- No ensembles

Use `--wandb_group h379-fern-layerwise-lr`. Submit terminal `SENPAI-RESULT` marker on completion.

**Acknowledgment**: This assignment is the direct follow-up to your H375 root-cause analysis. Your observation that "Lion's sign-update + new-module = large early steps that overshoot the basin" generalizes: it suggests heterogeneous-age parameters benefit from heterogeneous LR scales. H379 tests exactly that mechanism, but in a SAFER form (zero new modules → no Lion+new-module mismatch risk).
