### PR TITLE
[codex] Add volume velocity training targets

### DIFF
--- a/data/loader.py
+++ b/data/loader.py
@@ -14,8 +14,10 @@ The processed dataset provides one directory per case containing `.npy` arrays:
 - `volume_xyz.npy`
 - `volume_sdf.npy`
 - `volume_pressure.npy`
+- `volume_velocity.npy`
 
-This repo predicts surface pressure, wall shear / friction, and volume pressure.
+This repo predicts surface pressure, wall shear / friction, volume pressure,
+and volume velocity.
 """
 
 from __future__ import annotations
@@ -38,9 +40,9 @@ DEFAULT_MANIFEST = Path(__file__).with_name("split_manifest.json")
 SURFACE_X_DIM = 7  # xyz(3) + normals(3) + panel area(1)
 SURFACE_Y_DIM = 4  # cp(1) + wall shear stress(3)
 VOLUME_X_DIM = 4  # xyz(3) + sdf(1)
-VOLUME_Y_DIM = 1  # volume pressure
+VOLUME_Y_DIM = 4  # volume pressure + velocity
 SURFACE_TARGET_NAMES = ("surface_pressure", "wall_shear_x", "wall_shear_y", "wall_shear_z")
-VOLUME_TARGET_NAMES = ("volume_pressure",)
+VOLUME_TARGET_NAMES = ("volume_pressure", "volume_velocity_x", "volume_velocity_y", "volume_velocity_z")
 EXPECTED_SURFACE_SPLIT_COUNTS = {"train": 400, "val": 34, "test": 50}
 EXPECTED_EXCLUDED_CASE_COUNT = 0
 REQUIRED_RESTORED_CASE_IDS = frozenset(
@@ -294,7 +296,12 @@ def load_case(
         ],
         axis=1,
     )
-    volume_y = _column(_load_npy_rows(case_dir / "volume_pressure.npy", volume_rows))
+    volume_pressure = _column(_load_npy_rows(case_dir / "volume_pressure.npy", volume_rows))
+    volume_velocity = _three_column(
+        _load_npy_rows(case_dir / "volume_velocity.npy", volume_rows),
+        "volume_velocity.npy",
+    )
+    volume_y = np.concatenate([volume_pressure, volume_velocity], axis=1)
     return DrivAerMLCase(
         case_id=case_id,
         surface_x=torch.from_numpy(surface_x),
@@ -527,11 +534,12 @@ def target_stats_from_normalizers(store: DrivAerMLCaseStore) -> dict[str, torch.
     surface_cp_mean, surface_cp_std = _normalizer_tensor(raw, "surface_cp", 1)
     wall_shear_mean, wall_shear_std = _normalizer_tensor(raw, "surface_wallshearstress", 3)
     volume_pressure_mean, volume_pressure_std = _normalizer_tensor(raw, "volume_pressure", 1)
+    volume_velocity_mean, volume_velocity_std = _normalizer_tensor(raw, "volume_velocity", 3)
     return {
         "surface_y_mean": torch.cat([surface_cp_mean, wall_shear_mean]),
         "surface_y_std": torch.cat([surface_cp_std, wall_shear_std]),
-        "volume_y_mean": volume_pressure_mean,
-        "volume_y_std": volume_pressure_std,
+        "volume_y_mean": torch.cat([volume_pressure_mean, volume_velocity_mean]),
+        "volume_y_std": torch.cat([volume_pressure_std, volume_velocity_std]),
     }
 
 

--- a/scripts/compute_volume_velocity_normalizer.py
+++ b/scripts/compute_volume_velocity_normalizer.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Compute train-split volume_velocity target normalizers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", default="data/split_manifest.json")
+    parser.add_argument("--data-root", required=True)
+    parser.add_argument("--chunk-rows", type=int, default=1_000_000)
+    parser.add_argument("--write", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    manifest = json.loads(Path(args.manifest).read_text())
+    train_ids = manifest["surface_splits"]["train"]
+    root = Path(args.data_root)
+    total = 0
+    sums = np.zeros(3, dtype=np.float64)
+    sum_squares = np.zeros(3, dtype=np.float64)
+
+    for index, case_id in enumerate(train_ids, start=1):
+        path = root / case_id / "volume_velocity.npy"
+        values = np.load(path, mmap_mode="r")
+        if values.ndim != 2 or values.shape[1] != 3:
+            raise ValueError(f"{path} must have shape [N, 3], got {values.shape}")
+        for start in range(0, values.shape[0], args.chunk_rows):
+            chunk = np.asarray(values[start : start + args.chunk_rows], dtype=np.float64)
+            total += int(chunk.shape[0])
+            sums += chunk.sum(axis=0)
+            sum_squares += np.square(chunk).sum(axis=0)
+        print(f"{index:03d}/{len(train_ids)} {case_id} rows={values.shape[0]}", flush=True)
+
+    mean = sums / total
+    variance = np.maximum(sum_squares / total - np.square(mean), 0.0)
+    std = np.sqrt(variance)
+    stats = {
+        "mean": mean.tolist(),
+        "std": std.tolist(),
+        "count": int(total),
+    }
+    print(json.dumps({"volume_velocity": stats}, indent=2))
+
+    if args.write:
+        normalizers_path = root / "normalizers.json"
+        raw = json.loads(normalizers_path.read_text())
+        raw["volume_velocity"] = stats
+        normalizers_path.write_text(json.dumps(raw, indent=2, sort_keys=True) + "\n")
+        print(f"wrote {normalizers_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -325,7 +325,7 @@ def apply_y_symmetry_aug(batch, prob: float) -> torch.Tensor:
     - surface_x: [x, y, z, nx, ny, nz, area]  -> negate idx 1 and idx 4
     - surface_y: [cp, tau_x, tau_y, tau_z]    -> negate idx 2
     - volume_x:  [x, y, z, sdf]               -> negate idx 1
-    - volume_y:  [pressure]                   -> invariant
+    - volume_y:  [pressure, Ux, Uy, Uz]        -> negate Uy idx 2
     """
     B = batch.surface_x.shape[0]
     flip_mask = torch.rand(B, device=batch.surface_x.device) < prob
@@ -335,6 +335,7 @@ def apply_y_symmetry_aug(batch, prob: float) -> torch.Tensor:
         batch.surface_x[idx, :, 4] = -batch.surface_x[idx, :, 4]
         batch.surface_y[idx, :, 2] = -batch.surface_y[idx, :, 2]
         batch.volume_x[idx, :, 1] = -batch.volume_x[idx, :, 1]
+        batch.volume_y[idx, :, 2] = -batch.volume_y[idx, :, 2]
     return flip_mask
 
 
@@ -388,8 +389,8 @@ def train_loss(
         # landscape, otherwise the H19 mechanism is invisible to the
         # dynamic-weight balancing — root cause flagged in run i4zt1zrl).
         if vol_p_charbonnier_weight > 0.0:
-            pred_vol_p = out["volume_preds"]  # [B, N_vol, 1]
-            target_vol_p = volume_target
+            pred_vol_p = out["volume_preds"][..., :1]
+            target_vol_p = volume_target[..., :1]
             loss_vol_p_charb = masked_charbonnier(
                 pred_vol_p,
                 target_vol_p,
@@ -427,16 +428,22 @@ def train_loss(
                 # now w_vol_p * Charb_vol_p via the weighted sum below —
                 # adding a separate `vol_p_charb_weight * Charb` term would
                 # double-count.
-                volume_per_ch = loss_vol_p_charb.unsqueeze(0) * volume_loss_weight  # [1]
+                volume_mse_per_ch = per_channel_masked_mse(
+                    out["volume_preds"], volume_target, batch.volume_mask
+                )
+                volume_per_ch = volume_mse_per_ch * volume_loss_weight
+                volume_per_ch = torch.cat(
+                    [loss_vol_p_charb.unsqueeze(0) * volume_loss_weight, volume_per_ch[1:]]
+                )
             else:
                 volume_per_ch = per_channel_masked_mse(
                     out["volume_preds"], volume_target, batch.volume_mask
-                ) * volume_loss_weight  # [1]: vol_p MSE
-            task_losses = torch.cat([surface_per_ch, volume_per_ch])  # [5]
+                ) * volume_loss_weight  # [4]: vol_p, Ux, Uy, Uz
+            task_losses = torch.cat([surface_per_ch, volume_per_ch])  # cp, tau_x/y/z, vol_p, vol_Ux/y/z
             w_detached = gradnorm_weights.weights.detach()
             loss = (w_detached * task_losses).sum()
             weighted_surface_loss = (w_detached[:4] * surface_per_ch).sum()
-            weighted_volume_loss = w_detached[4] * volume_per_ch[0]
+            weighted_volume_loss = (w_detached[4:] * volume_per_ch).sum()
         else:
             task_losses = None
             weighted_surface_loss = surface_loss_weight * surface_loss
@@ -643,8 +650,8 @@ def main(argv: Iterable[str] | None = None) -> None:
         gradnorm_weights: GradNormWeights | None = None
         gradnorm_opt: torch.optim.Optimizer | None = None
         gradnorm_L0: torch.Tensor | None = None
-        gradnorm_n_tasks = 5  # cp, tau_x, tau_y, tau_z, vol_p
-        gradnorm_task_names = ("cp", "tau_x", "tau_y", "tau_z", "vol_p")
+        gradnorm_task_names = ("cp", "tau_x", "tau_y", "tau_z", "vol_p", "vol_u", "vol_v", "vol_w")
+        gradnorm_n_tasks = len(gradnorm_task_names)
         if config.use_gradnorm:
             gradnorm_weights = GradNormWeights(n_tasks=gradnorm_n_tasks).to(device)
             gradnorm_opt = torch.optim.Adam(

--- a/trainer_runtime.py
+++ b/trainer_runtime.py
@@ -1011,6 +1011,10 @@ EVAL_KEYS = (
     "wall_shear_y",
     "wall_shear_z",
     "volume_pressure",
+    "volume_velocity",
+    "volume_velocity_x",
+    "volume_velocity_y",
+    "volume_velocity_z",
 )
 
 
@@ -1130,6 +1134,15 @@ def accumulate_eval_batch(
         volume_abs = (volume_pred - batch.volume_y).abs()[batch.volume_mask]
         accumulator.abs_sums["volume_pressure"] += float(volume_abs[:, 0].sum().detach().cpu().item())
         accumulator.abs_counts["volume_pressure"] += int(volume_abs[:, 0].numel())
+        velocity_abs = volume_abs[:, 1:4]
+        accumulator.abs_sums["volume_velocity"] += float(velocity_abs.sum().detach().cpu().item())
+        accumulator.abs_counts["volume_velocity"] += int(velocity_abs.numel())
+        for offset, axis in enumerate(("x", "y", "z")):
+            channel = velocity_abs[:, offset]
+            accumulator.abs_sums[f"volume_velocity_{axis}"] += float(
+                channel.sum().detach().cpu().item()
+            )
+            accumulator.abs_counts[f"volume_velocity_{axis}"] += int(channel.numel())
 
     for case_idx, case_id in enumerate(batch.case_ids):
         surface_valid = batch.surface_mask[case_idx].bool()
@@ -1157,12 +1170,27 @@ def accumulate_eval_batch(
                 )
         volume_valid = batch.volume_mask[case_idx].bool()
         if bool(volume_valid.any()):
+            volume_pred_valid = volume_pred[case_idx][volume_valid]
+            volume_target_valid = batch.volume_y[case_idx][volume_valid]
             _accumulate_case_rel_l2(
                 accumulator.case_sums["volume_pressure"],
                 case_id=case_id,
-                pred=volume_pred[case_idx][volume_valid],
-                target=batch.volume_y[case_idx][volume_valid],
+                pred=volume_pred_valid[:, 0:1],
+                target=volume_target_valid[:, 0:1],
             )
+            _accumulate_case_rel_l2(
+                accumulator.case_sums["volume_velocity"],
+                case_id=case_id,
+                pred=volume_pred_valid[:, 1:4],
+                target=volume_target_valid[:, 1:4],
+            )
+            for channel, axis in enumerate(("x", "y", "z"), start=1):
+                _accumulate_case_rel_l2(
+                    accumulator.case_sums[f"volume_velocity_{axis}"],
+                    case_id=case_id,
+                    pred=volume_pred_valid[:, channel : channel + 1],
+                    target=volume_target_valid[:, channel : channel + 1],
+                )
 
 
 def merge_eval_accumulators(accumulators: Iterable[EvalAccumulator]) -> EvalAccumulator:
@@ -1191,6 +1219,10 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
     wall_shear_y_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_y"])
     wall_shear_z_rel_l2, _ = _rel_l2(accumulator.case_sums["wall_shear_z"])
     volume_pressure_rel_l2, volume_cases = _rel_l2(accumulator.case_sums["volume_pressure"])
+    volume_velocity_rel_l2, _ = _rel_l2(accumulator.case_sums["volume_velocity"])
+    volume_velocity_x_rel_l2, _ = _rel_l2(accumulator.case_sums["volume_velocity_x"])
+    volume_velocity_y_rel_l2, _ = _rel_l2(accumulator.case_sums["volume_velocity_y"])
+    volume_velocity_z_rel_l2, _ = _rel_l2(accumulator.case_sums["volume_velocity_z"])
     abupt_axis_mean_rel_l2 = _finite_mean(
         [
             surface_pressure_rel_l2,
@@ -1221,6 +1253,10 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
         "wall_shear_y_mae": mae_values["wall_shear_y"],
         "wall_shear_z_mae": mae_values["wall_shear_z"],
         "volume_pressure_mae": mae_values["volume_pressure"],
+        "volume_velocity_mae": mae_values["volume_velocity"],
+        "volume_velocity_x_mae": mae_values["volume_velocity_x"],
+        "volume_velocity_y_mae": mae_values["volume_velocity_y"],
+        "volume_velocity_z_mae": mae_values["volume_velocity_z"],
         "surface_pressure_rel_l2": surface_pressure_rel_l2,
         "surface_pressure_rel_l2_pct": surface_pressure_rel_l2 * 100.0,
         "wall_shear_rel_l2": wall_shear_rel_l2,
@@ -1233,6 +1269,14 @@ def finalize_eval_accumulator(accumulator: EvalAccumulator) -> dict[str, float]:
         "wall_shear_z_rel_l2_pct": wall_shear_z_rel_l2 * 100.0,
         "volume_pressure_rel_l2": volume_pressure_rel_l2,
         "volume_pressure_rel_l2_pct": volume_pressure_rel_l2 * 100.0,
+        "volume_velocity_rel_l2": volume_velocity_rel_l2,
+        "volume_velocity_rel_l2_pct": volume_velocity_rel_l2 * 100.0,
+        "volume_velocity_x_rel_l2": volume_velocity_x_rel_l2,
+        "volume_velocity_x_rel_l2_pct": volume_velocity_x_rel_l2 * 100.0,
+        "volume_velocity_y_rel_l2": volume_velocity_y_rel_l2,
+        "volume_velocity_y_rel_l2_pct": volume_velocity_y_rel_l2 * 100.0,
+        "volume_velocity_z_rel_l2": volume_velocity_z_rel_l2,
+        "volume_velocity_z_rel_l2_pct": volume_velocity_z_rel_l2 * 100.0,
         "abupt_axis_mean_rel_l2": abupt_axis_mean_rel_l2,
         "abupt_axis_mean_rel_l2_pct": abupt_axis_mean_rel_l2 * 100.0,
         "cases": max(surface_cases, wall_shear_cases, volume_cases),
@@ -1346,6 +1390,7 @@ def print_metrics(prefix: str, metrics: dict[str, float]) -> None:
         f"abupt_axis_rel_l2_pct={metrics['abupt_axis_mean_rel_l2_pct']:.4f} "
         f"surface_p_mae={metrics['surface_pressure_mae']:.5f} "
         f"volume_p_mae={metrics['volume_pressure_mae']:.5f} "
+        f"volume_u_mae={metrics['volume_velocity_mae']:.5f} "
         f"wall_shear_mae={metrics['wall_shear_mae']:.5f} "
         f"cases={int(metrics['cases'])}"
     )
@@ -1357,12 +1402,17 @@ PRIMARY_METRIC_KEYS = (
     "surface_pressure_mae",
     "wall_shear_mae",
     "volume_pressure_mae",
+    "volume_velocity_mae",
     "surface_pressure_rel_l2_pct",
     "wall_shear_rel_l2_pct",
     "wall_shear_x_rel_l2_pct",
     "wall_shear_y_rel_l2_pct",
     "wall_shear_z_rel_l2_pct",
     "volume_pressure_rel_l2_pct",
+    "volume_velocity_rel_l2_pct",
+    "volume_velocity_x_rel_l2_pct",
+    "volume_velocity_y_rel_l2_pct",
+    "volume_velocity_z_rel_l2_pct",
 )
 
 


### PR DESCRIPTION
## Summary

Adds the three volume velocity components (`Ux`, `Uy`, `Uz`) as volume training targets on top of the #1344 H147 recipe.

## Changes

- Loads `volume_velocity.npy` and concatenates it with volume pressure so `volume_y = [pressure, Ux, Uy, Uz]`.
- Extends volume target normalization to use the `volume_velocity` entry in `normalizers.json`.
- Updates y-symmetry augmentation so `Uy` flips with the mirrored volume coordinates.
- Expands GradNorm from 5 tasks to 8 tasks and keeps the pressure Charbonnier path scoped to volume-pressure only.
- Logs aggregate and per-axis volume velocity eval metrics.
- Adds `scripts/compute_volume_velocity_normalizer.py` for train-split velocity normalizer generation.

## Experiment Links

- Volume-velocity run: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/jc7zjldj
- Same-date #1344 baseline repro: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/runs/e9syvh1w
- Comparison report: https://wandb.ai/wandb-applied-ai-team/senpai-v1-drivaerml-ddp8/reports/[2026-06-18]-DrivAerML-H147-Repro-vs-Volume-Velocity-Targets--VmlldzoxNzI3MTE5MQ==

## Validation

- `python -m py_compile data/loader.py train.py trainer_runtime.py scripts/compute_volume_velocity_normalizer.py`
- Completed W&B run `jc7zjldj` with volume velocity metrics logged.

## Notes

The same-date pressure-only baseline repro did not reproduce the historical #1344 run quality, so the W&B report compares the velocity-target run primarily against that same-date control.